### PR TITLE
fix: change default action to container

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # action-semantic-release
 
-![workflow](https://github.com/quike/action-semantic-release/workflows/push/badge.svg)
+[![Push](https://github.com/quike/action-semantic-release/actions/workflows/release.yml/badge.svg)](https://github.com/quike/action-semantic-release/actions/workflows/release.yml)
+[![Release Workflow](https://github.com/quike/action-semantic-release/actions/workflows/release-container.yml/badge.svg)](https://github.com/quike/action-semantic-release/actions/workflows/release-container.yml)
 ![GitHub Release](https://img.shields.io/github/v/release/quike/action-semantic-release)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 

--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,7 @@ outputs:
 
 runs:
   using: "docker"
-  image: "Dockerfile"
+  image: "docker://ghcr.io/quike/action-semantic-release:1"
   env:
     GH_TOKEN: ${{ inputs.token }}
     DRY_RUN: ${{ inputs.dry-run }}

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -73,9 +73,9 @@ The following piece of code is an example used in the default configuration. Thi
 
 #### Action Variables
 
-| _Variable_                 | _Default_               | _Details_                     |
-| -------------------------- | ----------------------- | ----------------------------- |
-| **token**                  | `GH_TOKEN` GitHub Token | GitHub Enterprise User Token. |
-| **debug-mode**             | `false`                 | To enable verbosity           |
-| **dry-run**                | `false`                 | Dry Run execution             |
-| **default-config-enabled** | `true`                  | Dry Run execution             |
+| _Variable_                 | _Default_               | _Details_                           |
+| -------------------------- | ----------------------- | ----------------------------------- |
+| **token**                  | `GH_TOKEN` GitHub Token | GitHub Enterprise User Token.       |
+| **debug-mode**             | `false`                 | To enable verbosity                 |
+| **dry-run**                | `false`                 | Dry Run execution                   |
+| **default-config-enabled** | `true`                  | Force default config if not present |


### PR DESCRIPTION
So now we already have a container built and running, we must change the flow so any consumer of the action uses the pre cooked image, instead of forcing constantly the installation of dependencies.