### PR TITLE
fix: set proper default file location

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,7 +31,7 @@ config() {
   npm link @actions/core
   bash -c "git config --global --add safe.directory \$PWD"
   CONFIG_EXISTS=false
-  DEFAULT_CONFIG="/usr/src/config/.releaserc.default"
+  DEFAULT_CONFIG="/.releaserc.default"
   CONFIG_FILES=".releaserc .releaserc.json .releaserc.yaml .releaserc.yml .releaserc.js .releaserc.cjs release.config.js release.config.cjs"
   for CONF_FILE in ${CONFIG_FILES}; do
     if [ -e "${CONF_FILE}" ]; then


### PR DESCRIPTION
This was producing the following scenario:

```
[entrypoint.sh] A valid config file cannot be found. Trying default config.
[entrypoint.sh] DEFAULT_CONFIG_ENABLED: true. Copying default config.
[entrypoint.sh] Unable to find default config file /usr/src/config/.releaserc.default
```

So the app wasn't able to find the file in that location.