### PR TITLE
feat: move working dir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,11 +19,15 @@ RUN apk add --no-cache --update \
   git \
   jq
 
+# Set an environment variable using the build argument
+ENV WORKING_DIR=${WORKING_PATH}
+WORKDIR $WORKING_DIR
+
 COPY package.json /global-package.json
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 RUN jq -r '.dependencies | keys | join(" ")' < /global-package.json | xargs npm install -g
 
-COPY entrypoint.sh /entrypoint.sh
-COPY .releaserc.default /.releaserc.default
+COPY entrypoint.sh ${WORKING_DIR}/entrypoint.sh
+COPY .releaserc.default ${WORKING_DIR}/.releaserc.default
 
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["/bin/bash", "-c", "$WORKING_DIR/entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -20,4 +20,11 @@ release: config
 	@echo "Execute entrypoint"
 	./entrypoint.sh
 
+.PHONY: docker-build
+docker-build:
+	docker build -t $(OWNER)/$(COMPONENT):$(VERSION) .
+
+.PHONY: docker-run
+docker-run:
+	docker run --rm -it -v $(PWD):/github/workspace -e GH_TOKEN=$GH_TOKEN -d $(OWNER)/$(COMPONENT):$(VERSION)
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,6 +24,7 @@ verify_parameter() {
 verify_requirements() {
   print "${FUNCNAME[0]}"
   verify_parameter "${GH_TOKEN}" "GH_TOKEN" "true"
+  verify_parameter "${WORKING_DIR}" "WORKING_DIR" "false"
 }
 
 config() {
@@ -31,7 +32,7 @@ config() {
   npm link @actions/core
   bash -c "git config --global --add safe.directory \$PWD"
   CONFIG_EXISTS=false
-  DEFAULT_CONFIG="/.releaserc.default"
+  DEFAULT_CONFIG="${WORKING_DIR}/.releaserc.default"
   CONFIG_FILES=".releaserc .releaserc.json .releaserc.yaml .releaserc.yml .releaserc.js .releaserc.cjs release.config.js release.config.cjs"
   for CONF_FILE in ${CONFIG_FILES}; do
     if [ -e "${CONF_FILE}" ]; then


### PR DESCRIPTION
This should fix the idealTree as it is running in root `/` instead of specific location.

```
10 verbose logfile /root/.npm/_logs/2025-02-20T17_57_17_208Z-debug-0.log
11 silly packumentCache heap:2103181312 maxSize:525795328 maxEntrySize:262897664
12 silly logfile done cleaning log files
13 silly packumentCache heap:2103181312 maxSize:525795328 maxEntrySize:262897664
14 silly idealTree buildDeps
15 verbose stack Error: Tracker "idealTree" already exists
15 verbose stack     at #onError (/usr/local/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/tracker.js:84:11)
15 verbose stack     at Arborist.addTracker (/usr/local/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/tracker.js:26:20)
15 verbose stack     at #buildDeps (/usr/local/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/build-ideal-tree.js:753:10)
15 verbose stack     at Arborist.buildIdealTree (/usr/local/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/build-ideal-tree.js:181:28)
15 verbose stack     at async Promise.all (index 1)
15 verbose stack     at async Arborist.reify (/usr/local/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/reify.js:131:5)
15 verbose stack     at async Link.linkInstall (/usr/local/lib/node_modules/npm/lib/commands/link.js:123:5)
15 verbose stack     at async Npm.exec (/usr/local/lib/node_modules/npm/lib/npm.js:207:9)
15 verbose stack     at async module.exports (/usr/local/lib/node_modules/npm/lib/cli/entry.js:74:5)
16 error Tracker "idealTree" already exists
17 silly unfinished npm timer reify 1740074237360
18 silly unfinished npm timer reify:loadTrees 1740074237360
19 silly unfinished npm timer idealTree:buildDeps 1740074237365
```
