### PR TITLE
feat: add floating tags support

### DIFF
--- a/.releaserc.default
+++ b/.releaserc.default
@@ -12,6 +12,6 @@
   ],
   "preset": "conventionalcommits",
   "debug": true,
-  "dryRun": false,
+  "dryRun": true,
   "ci": false
 }

--- a/.releaserc.default
+++ b/.releaserc.default
@@ -14,6 +14,6 @@
   ],
   "preset": "conventionalcommits",
   "debug": true,
-  "dryRun": true,
+  "dryRun": false,
   "ci": false
 }

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,10 @@ inputs:
     description: 'Create a GitHub Job Summary.'
     required: false
     default: 'true'
+  floating-tags:
+    description: 'Create floating tags from major and minor versions after release.'
+    required: false
+    default: 'false'
 
 outputs:
   release-version:

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -71,6 +71,7 @@ jobs:
 | **dry-run**                | `false`   | Dry Run execution                                                                          |
 | **default-config-enabled** | `true`    | Force default config if not present                                                        |
 | **default-preset-info**    | `true`    | Sets prefixed release rules and preset configs as callback if default info does not exists |
+| **floating-tags**          | `false`   | Create floating tags from major and minor versions after release.                          |
 
 #### Environment Variables
 

--- a/src/set-floating-tags.js
+++ b/src/set-floating-tags.js
@@ -1,5 +1,5 @@
 import * as core from '@actions/core'
-import { tag } from 'semantic-release/lib/git'
+import { tag } from 'semantic-release/lib/git.js'
 
 export const setFloatingTags = async (release, { cwd = process.cwd(), env = process.env }) => {
   if (release) {

--- a/src/set-floating-tags.js
+++ b/src/set-floating-tags.js
@@ -1,0 +1,22 @@
+import * as core from '@actions/core'
+import { tag } from 'semantic-release/lib/git'
+
+export const setFloatingTags = async (release, { cwd = process.cwd(), env = process.env }) => {
+  if (!release) {
+    core.debug('Floating tags cannot be set.')
+    return {}
+  }
+
+  if (release?.new?.major && release?.new?.minor && release?.new?.gitHead) {
+    const majorTag = `v${release?.new?.major}`
+    const minorTag = `v${release?.new?.major}.${release?.new?.minor}`
+    const gitHead = release?.new?.gitHead
+    core.info(`Setting floating major tag: ${majorTag}`)
+    await tag(majorTag, '-d', { cwd, env })
+    await tag(majorTag, gitHead, { cwd, env })
+    core.info(`Setting floating minor tag: ${minorTag}`)
+    await tag(minorTag, '-d', { cwd, env })
+    await tag(minorTag, gitHead, { cwd, env })
+    return { majorTag, minorTag }
+  }
+}

--- a/src/set-floating-tags.js
+++ b/src/set-floating-tags.js
@@ -2,21 +2,21 @@ import * as core from '@actions/core'
 import { tag } from 'semantic-release/lib/git'
 
 export const setFloatingTags = async (release, { cwd = process.cwd(), env = process.env }) => {
-  if (!release) {
+  if (release) {
+    if (release.new?.major !== undefined && release.new?.minor !== undefined && release.new?.gitHead !== undefined) {
+      const majorTag = `v${release?.new?.major}`
+      const minorTag = `v${release?.new?.major}.${release?.new?.minor}`
+      const gitHead = release?.new?.gitHead
+      core.info(`Setting floating major tag: ${majorTag}`)
+      await tag(majorTag, '-d', { cwd, env })
+      await tag(majorTag, gitHead, { cwd, env })
+      core.info(`Setting floating minor tag: ${minorTag}`)
+      await tag(minorTag, '-d', { cwd, env })
+      await tag(minorTag, gitHead, { cwd, env })
+      return { majorTag, minorTag }
+    }
+  } else {
     core.debug('Floating tags cannot be set.')
-    return {}
   }
-
-  if (release?.new?.major && release?.new?.minor && release?.new?.gitHead) {
-    const majorTag = `v${release?.new?.major}`
-    const minorTag = `v${release?.new?.major}.${release?.new?.minor}`
-    const gitHead = release?.new?.gitHead
-    core.info(`Setting floating major tag: ${majorTag}`)
-    await tag(majorTag, '-d', { cwd, env })
-    await tag(majorTag, gitHead, { cwd, env })
-    core.info(`Setting floating minor tag: ${minorTag}`)
-    await tag(minorTag, '-d', { cwd, env })
-    await tag(minorTag, gitHead, { cwd, env })
-    return { majorTag, minorTag }
-  }
+  return {}
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -45,3 +45,15 @@ export const cleanObject = (obj) => {
 
   return obj
 }
+
+export const getBooleanInput = (name, options) => {
+  const input = core.getBooleanInput(name, options)
+  core.info(`${name}: ${input}`)
+  return input !== undefined ? input : options.default
+}
+
+export const getInput = (name, options) => {
+  const input = core.getInput(name, options)
+  core.info(`${name}: ${input}`)
+  return input !== undefined && input !== '' ? input : options.default
+}

--- a/test/set-floating-tags.test.js
+++ b/test/set-floating-tags.test.js
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, vi } from 'vitest'
 import * as core from '@actions/core'
 import { setFloatingTags } from '../src/set-floating-tags.js'
-import { tag } from 'semantic-release/lib/git'
+import { tag } from 'semantic-release/lib/git.js'
 
 vi.mock('@actions/core')
 vi.mock('semantic-release/lib/git')

--- a/test/set-floating-tags.test.js
+++ b/test/set-floating-tags.test.js
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, vi } from 'vitest'
+import * as core from '@actions/core'
+import { setFloatingTags } from '../src/set-floating-tags.js'
+import { tag } from 'semantic-release/lib/git'
+
+vi.mock('@actions/core')
+vi.mock('semantic-release/lib/git')
+
+describe('setSummary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('should log a debug message and return an empty object when no release is provided', async () => {
+    const result = await setFloatingTags(null, {})
+    expect(core.debug).toHaveBeenCalledWith('Floating tags cannot be set.')
+    expect(result).toEqual({})
+  })
+
+  it('should set floating major and minor tags when release has major, minor, and gitHead', async () => {
+    const release = {
+      new: {
+        major: 1,
+        minor: 0,
+        gitHead: 'abc123'
+      }
+    }
+
+    const result = await setFloatingTags(release, {})
+
+    expect(core.info).toHaveBeenCalledWith('Setting floating major tag: v1')
+    expect(core.info).toHaveBeenCalledWith('Setting floating minor tag: v1.0')
+    expect(tag).toHaveBeenCalledWith('v1', '-d', { cwd: process.cwd(), env: process.env })
+    expect(tag).toHaveBeenCalledWith('v1', 'abc123', { cwd: process.cwd(), env: process.env })
+    expect(tag).toHaveBeenCalledWith('v1.0', '-d', { cwd: process.cwd(), env: process.env })
+    expect(tag).toHaveBeenCalledWith('v1.0', 'abc123', { cwd: process.cwd(), env: process.env })
+    expect(result).toEqual({ majorTag: 'v1', minorTag: 'v1.0' })
+  })
+
+  it('should return an empty object when release does not have major, minor, or gitHead', async () => {
+    const release = {
+      new: {}
+    }
+
+    const result = await setFloatingTags(release, {})
+    expect(result).toEqual({})
+  })
+})

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { parseInput } from '../src/utils.js'
-import { cleanObject } from '../src/utils.js'
+import { parseInput, cleanObject, getBooleanInput, getInput } from '../src/utils.js'
 import * as core from '@actions/core'
 
 vi.mock('@actions/core')
@@ -117,5 +116,72 @@ describe('cleanObject', () => {
     }
     const result = cleanObject(input)
     expect(result).toEqual(expected)
+  })
+})
+
+describe('getBooleanInput', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should return the boolean input when provided', () => {
+    core.getBooleanInput.mockReturnValue(true)
+    const options = { default: false }
+
+    const result = getBooleanInput('test-input', options)
+
+    expect(core.getBooleanInput).toHaveBeenCalledWith('test-input', options)
+    expect(core.info).toHaveBeenCalledWith('test-input: true')
+    expect(result).toBe(true)
+  })
+
+  it('should return the default value when input is undefined', () => {
+    core.getBooleanInput.mockReturnValue(undefined)
+    const options = { default: false }
+
+    const result = getBooleanInput('test-input', options)
+
+    expect(core.getBooleanInput).toHaveBeenCalledWith('test-input', options)
+    expect(core.info).toHaveBeenCalledWith('test-input: undefined')
+    expect(result).toBe(false)
+  })
+})
+
+describe('getInput', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should return the input when provided', () => {
+    core.getInput.mockReturnValue('test-value')
+    const options = { default: 'default-value' }
+
+    const result = getInput('test-input', options)
+
+    expect(core.getInput).toHaveBeenCalledWith('test-input', options)
+    expect(core.info).toHaveBeenCalledWith('test-input: test-value')
+    expect(result).toBe('test-value')
+  })
+
+  it('should return the default value when input is undefined', () => {
+    core.getInput.mockReturnValue(undefined)
+    const options = { default: 'default-value' }
+
+    const result = getInput('test-input', options)
+
+    expect(core.getInput).toHaveBeenCalledWith('test-input', options)
+    expect(core.info).toHaveBeenCalledWith('test-input: undefined')
+    expect(result).toBe('default-value')
+  })
+
+  it('should return the default value when input is an empty string', () => {
+    core.getInput.mockReturnValue('')
+    const options = { default: 'default-value' }
+
+    const result = getInput('test-input', options)
+
+    expect(core.getInput).toHaveBeenCalledWith('test-input', options)
+    expect(core.info).toHaveBeenCalledWith('test-input: ')
+    expect(result).toBe('default-value')
   })
 })


### PR DESCRIPTION
https://github.com/quike/action-semantic-release/issues/13

If the specific configuration key is set in place, the code will try to tag repository for the major and minor versions within the expected commit. It should behave like a pointer, 
- if commit A has tag `v1.2.3` it would get `v1.2` and `v1`. 
- If commit B later has a tag `v1.2.4` if system tries to tag the floating tags it will fail as tags already exists. That is why we must first delete them and recreate them into the new commit.