### PR TITLE
chore: set floating tags for this action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,9 +52,16 @@ jobs:
           debug-mode: true
           dry-run: false
           default-config-enabled: true
+          floating-tags: true
         env:
           GITHUB_TOKEN: ${{ secrets.GHTOKEN }}
       - name: Get the output
         run: |
-          echo "The release version is ${{ steps.release.outputs.release-version }}"
-          echo "The relese sha is ${{ steps.release.outputs.release-git-head }}"
+          echo "release-published: ${{ steps.release.outputs.release-published }}"
+          echo "release-git-head: ${{ steps.release.outputs.release-version }}"
+          echo "release-major: ${{ steps.release.outputs.release-major }}"
+          echo "release-minor: ${{ steps.release.outputs.release-minor }}"
+          echo "release-patch: ${{ steps.release.outputs.release-patch }}"
+          echo "release-type: ${{ steps.release.outputs.release-type }}"
+          echo "release-git-head: ${{ steps.release.outputs.release-git-head }}"
+          echo "release-git-tag: ${{ steps.release.outputs.release-git-tag }}"

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -51,13 +51,15 @@ jobs:
         with:
           debug-mode: true
           dry-run: false
+          add-summary: true
           default-config-enabled: true
           default-preset-info: true
+          floating-tags: false
         env:
-          token: ${{ secrets.GHTOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GHTOKEN }}
     outputs:
       version: ${{ steps.release.outputs.release-version }}
-      git-head: ${{ steps.release.outputs.git-head }}
+      git-head: ${{ steps.release.outputs.release-git-head }}
 ```
 
 ### Parameters
@@ -89,13 +91,13 @@ The Action will export multiple variables so they can be accessed within your wo
 
 ### Exported Variables
 
-| _Variable_                | _GitHub Action Output_    | _Example_                                  | _Details_                                          |
-| ------------------------- | ------------------------- | ------------------------------------------ | -------------------------------------------------- |
-| **NEW_RELEASE_PUBLISHED** | **new-release-published** | `true`                                     | True if a new release is publised, false otherwise |
-| **RELEASE_VERSION**       | **release-version**       | `1.2.3`                                    | The new SemVer version of type X.Y.Z               |
-| **RELEASE_MAJOR**         | **release-major**         | `1`                                        | Major value of the new SemVer version              |
-| **RELEASE_MINOR**         | **release-minor**         | `2`                                        | Minor value of the new SemVer version              |
-| **RELEASE_PATCH**         | **release-patch**         | `3`                                        | Patch value of the new SemVer version              |
-| **RELEASE_TYPE**          | **type**                  | `patch`                                    | Type of SemVer release: major, minor or patch      |
-| **RELEASE_GIT_HEAD**      | **git-head**              | `cddc1177c51b518b3263b1b4f2b50af77dcf8be9` | Commig ID of the release                           |
-| **RELEASE_GIT_TAG**       | **name**                  | `v1.2.3`                                   | Tag ID associated with the release                 |
+| _Variable_            | _GitHub Action Output_ | _Example_                                  | _Details_                                           |
+| --------------------- | ---------------------- | ------------------------------------------ | --------------------------------------------------- |
+| **RELEASE_PUBLISHED** | **release-published**  | `true`                                     | True if a new release is published, false otherwise |
+| **RELEASE_VERSION**   | **release-version**    | `1.2.3`                                    | The new SemVer version of type X.Y.Z                |
+| **RELEASE_MAJOR**     | **release-major**      | `1`                                        | Major value of the new SemVer version               |
+| **RELEASE_MINOR**     | **release-minor**      | `2`                                        | Minor value of the new SemVer version               |
+| **RELEASE_PATCH**     | **release-patch**      | `3`                                        | Patch value of the new SemVer version               |
+| **RELEASE_TYPE**      | **release-type**       | `patch`                                    | Type of SemVer release: major, minor or patch       |
+| **RELEASE_GIT_HEAD**  | **release-git-head**   | `cddc1177c51b518b3263b1b4f2b50af77dcf8be9` | Commit ID of the release                            |
+| **RELEASE_GIT_TAG**   | **release-git-tag**    | `v1.2.3`                                   | Tag ID associated with the release                  |


### PR DESCRIPTION
Enabling the floating tags flag we expect to tag each release accordingly so consumers don't need to specify the whole semver.

Example of output:

```
release-published: true
release-git-head: 2.3.0
release-major: 2
release-minor: 3
release-patch: 0
release-type: minor
release-git-head: 6d2cede073118c1f3e46da9db9f387044e604fbd
release-git-tag: v2.3.0
```