### PR TITLE
chore: add github-actions default user

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,3 +1,11 @@
+const USER_NAME = 'github-actions[bot]'
+const USER_EMAIL = 'github-actions[bot]@users.noreply.github.com'
+
+export const DEFAULT_USER = {
+  USER_NAME,
+  USER_EMAIL
+}
+
 const DRY_RUN = { name: 'dry-run', required: false, default: false }
 const DEBUG_MODE = { name: 'debug-mode', required: false, default: true }
 const CI = { name: 'ci', required: false, default: true }

--- a/src/get-options.js
+++ b/src/get-options.js
@@ -1,7 +1,7 @@
 import * as core from '@actions/core'
 import { cleanObject, getBooleanInput } from './utils.js'
 import { getPlugins } from './get-plugins.js'
-import { INPUTS } from './constants.js'
+import { DEFAULT_USER, INPUTS } from './constants.js'
 
 /**
  * Retrieves and processes configuration options for the semantic release action.
@@ -38,10 +38,10 @@ export const getOptions = async (config) => {
     success: config.success || [],
     fail: config.fail || [],
     gitCredentials: {
-      GIT_AUTHOR_NAME: process.env.GIT_AUTHOR_NAME || '',
-      GIT_AUTHOR_EMAIL: process.env.GIT_AUTHOR_EMAIL || '',
-      GIT_COMMITTER_NAME: process.env.GIT_COMMITTER_NAME || '',
-      GIT_COMMITTER_EMAIL: process.env.GIT_COMMITTER_EMAIL || ''
+      GIT_AUTHOR_NAME: process.env.GIT_AUTHOR_NAME || DEFAULT_USER.USER_NAME,
+      GIT_AUTHOR_EMAIL: process.env.GIT_AUTHOR_EMAIL || DEFAULT_USER.USER_EMAIL,
+      GIT_COMMITTER_NAME: process.env.GIT_COMMITTER_NAME || DEFAULT_USER.USER_NAME,
+      GIT_COMMITTER_EMAIL: process.env.GIT_COMMITTER_EMAIL || DEFAULT_USER.USER_EMAIL
     }
   }
 

--- a/src/set-floating-tags.js
+++ b/src/set-floating-tags.js
@@ -1,5 +1,6 @@
 import * as core from '@actions/core'
 import { execa } from 'execa'
+import { DEFAULT_USER } from './constants'
 
 /**
  * Sets floating tags for the release.
@@ -16,6 +17,7 @@ export const setFloatingTags = async (release, { cwd = process.cwd(), env = proc
       const majorTag = `v${release?.new?.major}`
       const minorTag = `v${release?.new?.major}.${release?.new?.minor}`
       const gitHead = release?.new?.gitHead
+      await setUp({ cwd, env })
       await deleteTag(majorTag, { cwd, env })
       await createTag(majorTag, gitHead, { cwd, env })
       await deleteTag(minorTag, { cwd, env })
@@ -64,5 +66,23 @@ const createTag = async (myTag, gitHead, options) => {
     await execa('git', ['push', 'origin', myTag], options)
   } catch (error) {
     core.error(`Unable to create tag. Error: ${error}`)
+  }
+}
+
+/**
+ * Config version control details.
+ *
+ * @param {Object} options - Options for creating the tag.
+ * @param {string} [options.cwd=process.cwd()] - The current working directory.
+ * @param {Object} [options.env=process.env] - The environment variables.
+ * @returns {Promise<void>} Resolves when setup is completed.
+ */
+const setUp = async (options) => {
+  core.info(`Setting up env pre tagging with user: ${DEFAULT_USER.USER_NAME}`)
+  try {
+    await execa('git', ['config', 'user.name', DEFAULT_USER.USER_NAME], options)
+    await execa('git', ['config', 'user.email', DEFAULT_USER.USER_EMAIL], options)
+  } catch (error) {
+    core.error(`Unable to set up. Error: ${error}`)
   }
 }

--- a/src/set-floating-tags.js
+++ b/src/set-floating-tags.js
@@ -1,6 +1,6 @@
 import * as core from '@actions/core'
 import { execa } from 'execa'
-import { DEFAULT_USER } from './constants'
+import { DEFAULT_USER } from './constants.js'
 
 /**
  * Sets floating tags for the release.

--- a/test/get-options.test.js
+++ b/test/get-options.test.js
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import * as core from '@actions/core'
 import { getOptions } from '../src/get-options.js'
+import { DEFAULT_USER } from '../src/constants.js'
 
 vi.mock('@actions/core')
 
@@ -26,7 +27,13 @@ describe('getOptions', () => {
       branches: ['master', 'main'],
       ci: true,
       debug: true,
-      dryRun: false
+      dryRun: false,
+      gitCredentials: {
+        GIT_AUTHOR_NAME: DEFAULT_USER.USER_NAME,
+        GIT_AUTHOR_EMAIL: DEFAULT_USER.USER_EMAIL,
+        GIT_COMMITTER_NAME: DEFAULT_USER.USER_NAME,
+        GIT_COMMITTER_EMAIL: DEFAULT_USER.USER_EMAIL
+      }
     }
     expect(result).toEqual(expected)
     expect(core.info).toHaveBeenCalledWith(`Options: ${JSON.stringify(expected)}`)
@@ -53,7 +60,13 @@ describe('getOptions', () => {
       ci: true,
       debug: false,
       dryRun: false,
-      tagFormat: `v\${version}`
+      tagFormat: `v\${version}`,
+      gitCredentials: {
+        GIT_AUTHOR_NAME: DEFAULT_USER.USER_NAME,
+        GIT_AUTHOR_EMAIL: DEFAULT_USER.USER_EMAIL,
+        GIT_COMMITTER_NAME: DEFAULT_USER.USER_NAME,
+        GIT_COMMITTER_EMAIL: DEFAULT_USER.USER_EMAIL
+      }
     }
     const result = await getOptions(config)
     const expected = config
@@ -119,7 +132,13 @@ describe('getOptions', () => {
       prepare: ['prepare1'],
       publish: ['publish1'],
       success: ['success1'],
-      fail: ['fail1']
+      fail: ['fail1'],
+      gitCredentials: {
+        GIT_AUTHOR_NAME: DEFAULT_USER.USER_NAME,
+        GIT_AUTHOR_EMAIL: DEFAULT_USER.USER_EMAIL,
+        GIT_COMMITTER_NAME: DEFAULT_USER.USER_NAME,
+        GIT_COMMITTER_EMAIL: DEFAULT_USER.USER_EMAIL
+      }
     }
     expect(result).toEqual(expected)
     expect(core.info).toHaveBeenCalledWith(`Options: ${JSON.stringify(expected)}`)

--- a/test/set-floating-tags.test.js
+++ b/test/set-floating-tags.test.js
@@ -2,11 +2,12 @@ import { afterEach, beforeEach, describe, vi } from 'vitest'
 import * as core from '@actions/core'
 import { setFloatingTags } from '../src/set-floating-tags.js'
 import { execa } from 'execa'
+import { DEFAULT_USER } from '../src/constants.js'
 
 vi.mock('@actions/core')
 vi.mock('execa')
 
-describe('setSummary', () => {
+describe('setFloatingTags', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
@@ -32,8 +33,17 @@ describe('setSummary', () => {
 
     const result = await setFloatingTags(release, {})
 
+    expect(core.info).toHaveBeenCalledWith('Setting up env pre tagging with user: ' + DEFAULT_USER.USER_NAME)
     expect(core.info).toHaveBeenCalledWith('Creating tag: v1')
     expect(core.info).toHaveBeenCalledWith('Creating tag: v1.0')
+    expect(execa).toHaveBeenCalledWith('git', ['config', 'user.name', DEFAULT_USER.USER_NAME], {
+      cwd: process.cwd(),
+      env: process.env
+    })
+    expect(execa).toHaveBeenCalledWith('git', ['config', 'user.email', DEFAULT_USER.USER_EMAIL], {
+      cwd: process.cwd(),
+      env: process.env
+    })
     expect(execa).toHaveBeenCalledWith('git', ['tag', 'v1', '-d'], { cwd: process.cwd(), env: process.env })
     expect(execa).toHaveBeenCalledWith('git', ['tag', 'v1', 'abc123'], { cwd: process.cwd(), env: process.env })
     expect(execa).toHaveBeenCalledWith('git', ['tag', 'v1.0', '-d'], { cwd: process.cwd(), env: process.env })


### PR DESCRIPTION
As a github token is required, if the comes from a non headless user, it will show the user in all releases. Instead we rather avoid that, having the default user listed.

<img width="537" alt="Screenshot 2025-03-10 at 1 10 50 PM" src="https://github.com/user-attachments/assets/4e1044e5-285c-4360-a8d0-ecebb1884550" />
<img width="545" alt="Screenshot 2025-03-10 at 1 11 05 PM" src="https://github.com/user-attachments/assets/e3c53057-2562-493a-b456-aea27171145c" />
