### PR TITLE
feat: add metadata file to export variables

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -70,17 +70,17 @@ export_metadata() {
   INPUT_FILE="$GITHUB_ENV"
   OUTPUT_FILE="$WORKING_PATH/metadata.env"
   if [ -f "$INPUT_FILE" ] && [ -n "$EXPORT_METADATA" ] && [ "$EXPORT_METADATA" = true ]; then
-    true > "$OUTPUT_FILE"
+    true >"$OUTPUT_FILE"
 
     while IFS= read -r line; do
       if [[ "$line" == *"<<ghadelimiter_"* ]]; then
-        key="${line%%<<*}"  # Get part before << delimiter
+        key="${line%%<<*}" # Get part before << delimiter
         # Read value and delimiter end line
         IFS= read -r value
         IFS= read -r _end_delim
-        echo "$key=$value" >> "$OUTPUT_FILE"
+        echo "$key=$value" >>"$OUTPUT_FILE"
       fi
-    done < "$INPUT_FILE"
+    done <"$INPUT_FILE"
     if [ -f "$OUTPUT_FILE" ]; then
       print "Metadata file created successfully: $OUTPUT_FILE"
     else

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -55,14 +55,38 @@ validate() {
   echo "git-head=${CURRENT_SHA}" >>"$GITHUB_OUTPUT"
   echo "git-head=${CURRENT_SHA}" >>"$GITHUB_ENV"
   if [ -n "$EVENT_NAME" ] && [ "$EVENT_NAME" == "pull_request" ]; then
-    echo "Type of event: $EVENT_NAME"
+    print "Type of event: $EVENT_NAME"
     ORIGINAL_SHA=$(jq -r '.pull_request.head.sha' "$GITHUB_EVENT_PATH")
-    echo "Original Pull Request Commit ID: $ORIGINAL_SHA"
-    echo "HEAD is now at ${CURRENT_SHA} after Pull Request Commit Id merge with HEAD."
+    print "Original Pull Request Commit ID: $ORIGINAL_SHA"
+    print "HEAD is now at ${CURRENT_SHA} after Pull Request Commit Id merge with HEAD."
     PULL_REQUEST_VERSION=${ORIGINAL_SHA:0:7}
-    echo "Short SHA=${PULL_REQUEST_VERSION}"
+    print "Short SHA=${PULL_REQUEST_VERSION}"
     echo "release-version=${PULL_REQUEST_VERSION}" >>"$GITHUB_OUTPUT"
     echo "release-version=${PULL_REQUEST_VERSION}" >>"$GITHUB_ENV"
+  fi
+}
+
+export_metadata() {
+  INPUT_FILE="$GITHUB_ENV"
+  OUTPUT_FILE="$WORKING_PATH/metadata.env"
+  if [ -f "$INPUT_FILE" ] && [ -n "$EXPORT_METADATA" ] && [ "$EXPORT_METADATA" = true ]; then
+    true > "$OUTPUT_FILE"
+
+    while IFS= read -r line; do
+      if [[ "$line" == *"<<ghadelimiter_"* ]]; then
+        key="${line%%<<*}"  # Get part before << delimiter
+        # Read value and delimiter end line
+        IFS= read -r value
+        IFS= read -r _end_delim
+        echo "$key=$value" >> "$OUTPUT_FILE"
+      fi
+    done < "$INPUT_FILE"
+    if [ -f "$OUTPUT_FILE" ]; then
+      print "Metadata file created successfully: $OUTPUT_FILE"
+    else
+      print "Error: Metadata file was not created: $OUTPUT_FILE"
+      exit 4
+    fi
   fi
 }
 
@@ -72,6 +96,7 @@ main() {
   config "$@"
   run "$@"
   validate "$@"
+  export_metadata "$@"
 }
 
-main "$@"
+export_metadata "$@"


### PR DESCRIPTION
This change allows to export the GITHUB_ENV file pipeline metadata cleaning the unnecessary details to extract a key=value format.

`GITHUB_ENV` format example:

```properties
RELEASE_PUBLISHED<<ghadelimiter_497938e2-753a-4fbd-aa68-0b5bbea7b268
true
ghadelimiter_497938e2-753a-4fbd-aa68-0b5bbea7b268
RELEASE_VERSION<<ghadelimiter_9aead8f6-4ae3-4482-8ef2-0256f90ab7fd
1.0.8
ghadelimiter_9aead8f6-4ae3-4482-8ef2-0256f90ab7fd
RELEASE_MAJOR<<ghadelimiter_b54a1838-d33d-4349-a507-908d6aaadf4f
1
ghadelimiter_b54a1838-d33d-4349-a507-908d6aaadf4f
RELEASE_MINOR<<ghadelimiter_8bb2e45d-80d7-4d70-a6e7-62730fbf09fe
0
ghadelimiter_8bb2e45d-80d7-4d70-a6e7-62730fbf09fe
RELEASE_PATCH<<ghadelimiter_f6516c3e-635f-4484-9ad9-e6fbea335ed2
8
ghadelimiter_f6516c3e-635f-4484-9ad9-e6fbea335ed2
RELEASE_TYPE<<ghadelimiter_211571da-a498-488c-a75f-dbba3b598b42
patch
ghadelimiter_211571da-a498-488c-a75f-dbba3b598b42
RELEASE_GIT_HEAD<<ghadelimiter_a3008c53-9b33-42e1-b231-5ea801ca2e82
e202b5314faaf77e39cc1304fcca2cd723cc3bf5
ghadelimiter_a3008c53-9b33-42e1-b231-5ea801ca2e82
RELEASE_GIT_TAG<<ghadelimiter_0171efc9-c58c-4888-b4cc-020cf86122d6
v1.0.8
ghadelimiter_0171efc9-c58c-4888-b4cc-020cf86122d6
RELEASE_NAME<<ghadelimiter_51b15724-6bdb-4c1b-a316-7569cfbc06e8
v1.0.8
ghadelimiter_51b15724-6bdb-4c1b-a316-7569cfbc06e8
git-head=e202b5314faaf77e39cc1304fcca2cd723cc3bf5
```

`metadata.env` format example:

```
RELEASE_PUBLISHED=true
RELEASE_VERSION=1.0.8
RELEASE_MAJOR=1
RELEASE_MINOR=0
RELEASE_PATCH=8
RELEASE_TYPE=patch
RELEASE_GIT_HEAD=e202b5314faaf77e39cc1304fcca2cd723cc3bf5
RELEASE_GIT_TAG=v1.0.8
RELEASE_NAME=v1.0.8
```