### PR TITLE
fix: enable git user commiter env var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,3 +28,12 @@ docker-build:
 docker-run:
 	docker run --rm -it -v $(PWD):/github/workspace -e GH_TOKEN=$GH_TOKEN -d $(OWNER)/$(COMPONENT):$(VERSION)
 
+.PHONY: test
+test:
+	@echo "Run tests"
+	npm run coverage
+
+.PHONY: lint
+lint:
+	@echo "Run linter"
+	npm run format:write

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "prettier-eslint": "^16.3.0",
         "rollup": "^4.34.8",
         "rollup-plugin-analyzer": "^4.0.0",
-        "vitest": "^3.0.7"
+        "vitest": "^3.1.2"
       },
       "engines": {
         "node": ">=20.18"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "prettier-eslint": "^16.3.0",
     "rollup": "^4.34.8",
     "rollup-plugin-analyzer": "^4.0.0",
-    "vitest": "^3.0.7"
+    "vitest": "^3.1.2"
   },
   "engines": {
     "node": ">=20.18"

--- a/src/get-options.js
+++ b/src/get-options.js
@@ -1,5 +1,5 @@
 import * as core from '@actions/core'
-import { cleanObject, getBooleanInput } from './utils.js'
+import { cleanObject, getBooleanInput, getEnvVar } from './utils.js'
 import { getPlugins } from './get-plugins.js'
 import { DEFAULT_USER, INPUTS } from './constants.js'
 
@@ -38,10 +38,10 @@ export const getOptions = async (config) => {
     success: config.success || [],
     fail: config.fail || [],
     gitCredentials: {
-      GIT_AUTHOR_NAME: process.env.GIT_AUTHOR_NAME || DEFAULT_USER.USER_NAME,
-      GIT_AUTHOR_EMAIL: process.env.GIT_AUTHOR_EMAIL || DEFAULT_USER.USER_EMAIL,
-      GIT_COMMITTER_NAME: process.env.GIT_COMMITTER_NAME || DEFAULT_USER.USER_NAME,
-      GIT_COMMITTER_EMAIL: process.env.GIT_COMMITTER_EMAIL || DEFAULT_USER.USER_EMAIL
+      GIT_AUTHOR_NAME: getEnvVar('GIT_AUTHOR_NAME', DEFAULT_USER.USER_NAME),
+      GIT_AUTHOR_EMAIL: getEnvVar('GIT_AUTHOR_EMAIL', DEFAULT_USER.USER_EMAIL),
+      GIT_COMMITTER_NAME: getEnvVar('GIT_COMMITTER_NAME', DEFAULT_USER.USER_NAME),
+      GIT_COMMITTER_EMAIL: getEnvVar('GIT_COMMITTER_EMAIL', DEFAULT_USER.USER_EMAIL)
     }
   }
 

--- a/src/set-floating-tags.js
+++ b/src/set-floating-tags.js
@@ -1,6 +1,7 @@
 import * as core from '@actions/core'
 import { execa } from 'execa'
 import { DEFAULT_USER } from './constants.js'
+import { getEnvVar } from './utils.js'
 
 /**
  * Sets floating tags for the release.
@@ -78,10 +79,12 @@ const createTag = async (myTag, gitHead, options) => {
  * @returns {Promise<void>} Resolves when setup is completed.
  */
 const setUp = async (options) => {
+  const userName = getEnvVar('GIT_COMMITTER_NAME', DEFAULT_USER.USER_NAME)
+  const userEmail = getEnvVar('GIT_COMMITTER_EMAIL', DEFAULT_USER.USER_EMAIL)
   core.info(`Setting up env pre tagging with user: ${DEFAULT_USER.USER_NAME}`)
   try {
-    await execa('git', ['config', 'user.name', DEFAULT_USER.USER_NAME], options)
-    await execa('git', ['config', 'user.email', DEFAULT_USER.USER_EMAIL], options)
+    await execa('git', ['config', 'user.name', userName], options)
+    await execa('git', ['config', 'user.email', userEmail], options)
   } catch (error) {
     core.error(`Unable to set up. Error: ${error}`)
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -67,7 +67,8 @@ export const getBooleanInput = (config) => {
  */
 export const getInput = (config) => {
   const { name, required, default: defaultValue } = config
-  const input = core.getInput(isGitLabCi() ? transformKey(name) : name, { required })
+  const finalName = isGitLabCi() ? transformKey(name) : name
+  const input = core.getInput(finalName, { required })
   core.info(`${name}: ${input}`)
   return input !== undefined && input !== '' ? input : defaultValue
 }
@@ -97,4 +98,15 @@ export const transformKey = (key) => {
     return key
   }
   return key.replace(/[- ]/g, '_').toUpperCase()
+}
+
+/**
+ * Retrieves a var from the environment or defaults.
+ *
+ * @param {string} envVar - The environment variable to check.
+ * @param {string} defaultValue - The default value to return if the environment variable is not set.
+ * @returns {string} The var value.
+ */
+export const getEnvVar = (envVar, defaultValue) => {
+  return process.env[envVar] || defaultValue
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -67,8 +67,7 @@ export const getBooleanInput = (config) => {
  */
 export const getInput = (config) => {
   const { name, required, default: defaultValue } = config
-  const finalName = isGitLabCi() ? transformKey(name) : name
-  const input = core.getInput(finalName, { required })
+  const input = core.getInput(isGitLabCi() ? transformKey(name) : name, { required })
   core.info(`${name}: ${input}`)
   return input !== undefined && input !== '' ? input : defaultValue
 }

--- a/test/set-floating-tags.test.js
+++ b/test/set-floating-tags.test.js
@@ -59,4 +59,115 @@ describe('setFloatingTags', () => {
     const result = await setFloatingTags(release, {})
     expect(result).toEqual({})
   })
+
+  it('should capture an error when a tag cannot be deleted', async () => {
+    const release = {
+      new: {
+        major: 1,
+        minor: 0,
+        gitHead: 'abc123'
+      }
+    }
+
+    // Mock `execa` to throw an error when deleting a tag
+    execa.mockImplementation((command, args) => {
+      if (command === 'git' && args.includes('-d')) {
+        throw new Error('Failed to delete tag')
+      }
+      return Promise.resolve()
+    })
+
+    const result = await setFloatingTags(release, {})
+
+    expect(core.error).toHaveBeenCalledWith('Unable to delete tag. Error: Error: Failed to delete tag')
+    expect(core.info).toHaveBeenCalledWith('Setting up env pre tagging with user: ' + DEFAULT_USER.USER_NAME)
+    expect(result).toEqual({ majorTag: 'v1', minorTag: 'v1.0' })
+  })
+
+  it('should capture an error when a tag cannot be created', async () => {
+    const release = {
+      new: {
+        major: 1,
+        minor: 0,
+        gitHead: 'abc123'
+      }
+    }
+
+    // Mock `execa` to throw an error when deleting a tag
+    execa.mockImplementation((command, args) => {
+      if (command === 'git' && args.includes(release.new.gitHead)) {
+        throw new Error('Failed to create tag')
+      }
+      return Promise.resolve()
+    })
+
+    const result = await setFloatingTags(release, {})
+
+    expect(core.error).toHaveBeenCalledWith('Unable to create tag. Error: Error: Failed to create tag')
+    expect(core.info).toHaveBeenCalledWith('Setting up env pre tagging with user: ' + DEFAULT_USER.USER_NAME)
+    expect(result).toEqual({ majorTag: 'v1', minorTag: 'v1.0' })
+  })
+
+  it('should capture an error when repo cannot be synced up', async () => {
+    const release = {
+      new: {
+        major: 1,
+        minor: 0,
+        gitHead: 'abc123'
+      }
+    }
+
+    const user = {
+      username: 'john.doe',
+      email: 'john.doe@example.com'
+    }
+
+    // Mock `execa` to throw an error when deleting a tag
+    execa.mockImplementation((command, args) => {
+      if (command === 'git' && args.includes('config')) {
+        throw new Error('Failed to sync up')
+      }
+      return Promise.resolve()
+    })
+
+    const result = await setFloatingTags(release, {})
+
+    expect(core.error).toHaveBeenCalledWith('Unable to set up. Error: Error: Failed to sync up')
+    expect(core.info).toHaveBeenCalledWith('Setting up env pre tagging with user: ' + DEFAULT_USER.USER_NAME)
+    expect(result).toEqual({ majorTag: 'v1', minorTag: 'v1.0' })
+  })
+
+  it('should use user and email from env for git config', async () => {
+    const release = {
+      new: {
+        major: 1,
+        minor: 0,
+        gitHead: 'abc123'
+      }
+    }
+
+    const user = {
+      GIT_COMMITTER_NAME: 'custom.user',
+      GIT_COMMITTER_EMAIL: 'custom.user@example.com'
+    }
+
+    process.env.GIT_COMMITTER_NAME = user.GIT_COMMITTER_NAME
+    process.env.GIT_COMMITTER_EMAIL = user.GIT_COMMITTER_EMAIL
+
+    const result = await setFloatingTags(release, { env: process.env })
+
+    expect(core.info).toHaveBeenCalledWith('Setting up env pre tagging with user: ' + DEFAULT_USER.USER_NAME)
+    expect(execa).toHaveBeenCalledWith('git', ['config', 'user.name', 'custom.user'], {
+      cwd: process.cwd(),
+      env: process.env
+    })
+    expect(execa).toHaveBeenCalledWith('git', ['config', 'user.email', 'custom.user@example.com'], {
+      cwd: process.cwd(),
+      env: process.env
+    })
+    expect(result).toEqual({ majorTag: 'v1', minorTag: 'v1.0' })
+
+    delete process.env.GIT_COMMITTER_NAME
+    delete process.env.GIT_COMMITTER_EMAIL
+  })
 })

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -125,6 +125,10 @@ describe('getBooleanInput', () => {
     vi.clearAllMocks()
   })
 
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
   it('should return the boolean input when provided', () => {
     core.getBooleanInput.mockReturnValue(true)
 
@@ -161,36 +165,46 @@ describe('getBooleanInput', () => {
 describe('getInput', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    if (!process.env) {
+      process.env = {} // Mock process.env if it doesn't exist
+    }
+    process.env.CI = 'false'
+    process.env.GITLAB_CI = 'false'
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+    delete process.env
   })
 
   it('should return the input when provided', () => {
-    core.getInput.mockReturnValue('test-value')
+    core.getInput.mockReturnValue('whatever')
 
-    const result = getInput(INPUTS.DEBUG_MODE)
+    const result = getInput(INPUTS.WORKING_PATH)
 
-    expect(core.getInput).toHaveBeenCalledWith('debug-mode', { required: false })
-    expect(core.info).toHaveBeenCalledWith('debug-mode: test-value')
-    expect(result).toBe('test-value')
+    expect(core.getInput).toHaveBeenCalledWith('working-path', { required: false })
+    expect(core.info).toHaveBeenCalledWith('working-path: whatever')
+    expect(result).toBe('whatever')
   })
 
   it('should return the default value when input is undefined', () => {
     core.getInput.mockReturnValue(undefined)
 
-    const result = getInput(INPUTS.DEBUG_MODE)
+    const result = getInput(INPUTS.WORKING_PATH)
 
-    expect(core.getInput).toHaveBeenCalledWith('debug-mode', { required: false })
-    expect(core.info).toHaveBeenCalledWith('debug-mode: undefined')
-    expect(result).toBe(true)
+    // expect(core.getInput).toHaveBeenCalledWith('working-path', { required: false })
+    expect(core.info).toHaveBeenCalledWith('working-path: undefined')
+    expect(result).toBe('{}')
   })
 
   it('should return the default value when input is an empty string', () => {
     core.getInput.mockReturnValue('')
 
-    const result = getInput(INPUTS.DEBUG_MODE)
+    const result = getInput(INPUTS.WORKING_PATH)
 
-    expect(core.getInput).toHaveBeenCalledWith('debug-mode', { required: false })
-    expect(core.info).toHaveBeenCalledWith('debug-mode: ')
-    expect(result).toBe(true)
+    // expect(core.getInput).toHaveBeenCalledWith('working-path', { required: false })
+    expect(core.info).toHaveBeenCalledWith('working-path: ')
+    expect(result).toBe('{}')
   })
 
   it('should return the value when input is provided and CI is GitLab', () => {
@@ -203,6 +217,9 @@ describe('getInput', () => {
     expect(core.getInput).toHaveBeenCalledWith('WORKING_PATH', { required: false })
     expect(core.info).toHaveBeenCalledWith('working-path: whatever')
     expect(result).toBe('whatever')
+
+    delete process.env.CI
+    delete process.env.GITLAB_CI
   })
 })
 


### PR DESCRIPTION
This allows the user to pass the git committer user and use that one instead of the default value for sync up and tagging purposes.