### PR TITLE
fix: disable new unexpected linters

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -35,3 +35,7 @@ jobs:
           VALIDATE_JAVASCRIPT_STANDARD: false
           VALIDATE_JSCPD: false
           VALIDATE_JSON: false
+          VALIDATE_BIOME_FORMAT: false
+          VALIDATE_BIOME_LINT: false
+          VALIDATE_GITHUB_ACTIONS_ZIZMOR: false
+          VALIDATE_TRIVY: false


### PR DESCRIPTION
To fix https://github.com/quike/action-semantic-release/actions/runs/19009156694/job/54287473200 they never run before, now they are blocking the PRs