### PR TITLE
fix(ci)!: unblock release pipeline and auto-sync action.yml image tag

### DIFF
--- a/.github/workflows/release-container.yml
+++ b/.github/workflows/release-container.yml
@@ -76,8 +76,6 @@ jobs:
         with:
           ref: main
           token: ${{ secrets.GHTOKEN }}
-      - name: Install yq
-        run: sudo snap install yq
       - name: Compute released version
         id: version
         run: |

--- a/.github/workflows/release-container.yml
+++ b/.github/workflows/release-container.yml
@@ -77,12 +77,7 @@ jobs:
           ref: main
           token: ${{ secrets.GHTOKEN }}
       - name: Install yq
-        run: |
-          YQ_VERSION=v4.34.1
-          sudo wget \
-            "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" \
-            -O /usr/local/bin/yq
-          sudo chmod +x /usr/local/bin/yq
+        run: sudo snap install yq
       - name: Compute released version
         id: version
         run: |

--- a/.github/workflows/release-container.yml
+++ b/.github/workflows/release-container.yml
@@ -61,3 +61,51 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+  bump-action-image-tag:
+    name: Bump action.yml image to released version
+    needs: build-and-push-image
+    if: ${{ github.event_name == 'release' }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          token: ${{ secrets.GHTOKEN }}
+      - name: Install yq
+        run: |
+          YQ_VERSION=v4.34.1
+          sudo wget \
+            "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" \
+            -O /usr/local/bin/yq
+          sudo chmod +x /usr/local/bin/yq
+      - name: Compute released version
+        id: version
+        run: |
+          TAG_NAME="${{ github.event.release.tag_name }}"
+          VERSION="${TAG_NAME#v}"
+          echo "value=${VERSION}" >> "$GITHUB_OUTPUT"
+      - name: Update action.yml
+        run: |
+          yq -i ".runs.image = \"docker://${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.value }}\"" ./action.yml
+          grep "image:" ./action.yml
+      - name: Open bump PR
+        env:
+          GH_TOKEN: ${{ secrets.GHTOKEN }}
+        run: |
+          BRANCH="ci/bump-action-image-${{ steps.version.outputs.value }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add action.yml
+          git commit -m "ci: bump action.yml image to ${{ steps.version.outputs.value }}"
+          git push origin "$BRANCH"
+          gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "ci: bump action.yml image to ${{ steps.version.outputs.value }}" \
+            --body "Auto-generated after release \`v${{ steps.version.outputs.value }}\` to keep \`action.yml\` in sync with the published container image."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,11 +38,7 @@ jobs:
         run: |
           echo "Swap action.yml to local Dockerfile so the release runs against current source."
           grep "docker" < ./action.yml
-          YQ_VERSION=v4.34.1
-          sudo wget \
-            "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" \
-            -O /usr/local/bin/yq
-          sudo chmod +x /usr/local/bin/yq
+          sudo snap install yq
           yq -i '.runs.image = "Dockerfile"' ./action.yml
           echo "Now action under test points to internal image."
           grep "Dockerfile" < ./action.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,19 +34,18 @@ jobs:
       - name: Lint
         id: npm-lint
         run: npm run lint
-      - name: Set Test Environment
+      - name: Use local Dockerfile for action under test
         run: |
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            echo "To test action, we are going to change stable image to internal Dockerfile."
-            grep "docker" < ./action.yml
-            YQ_VERSION=v4.34.1
-            sudo wget \
+          echo "Swap action.yml to local Dockerfile so the release runs against current source."
+          grep "docker" < ./action.yml
+          YQ_VERSION=v4.34.1
+          sudo wget \
             "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" \
             -O /usr/local/bin/yq
-            yq -i '.runs.image = "Dockerfile"' ./action.yml
-            echo "Now action under test should point to internal image."
-            grep "Dockerfile" < ./action.yml
-          fi
+          sudo chmod +x /usr/local/bin/yq
+          yq -i '.runs.image = "Dockerfile"' ./action.yml
+          echo "Now action under test points to internal image."
+          grep "Dockerfile" < ./action.yml
       - name: Release
         id: release
         uses: ./

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,6 @@ jobs:
         run: |
           echo "Swap action.yml to local Dockerfile so the release runs against current source."
           grep "docker" < ./action.yml
-          sudo snap install yq
           yq -i '.runs.image = "Dockerfile"' ./action.yml
           echo "Now action under test points to internal image."
           grep "Dockerfile" < ./action.yml


### PR DESCRIPTION
## Summary

Two coupled fixes for the action-semantic-release release pipeline:

1. **Unblock main**: `release.yml` always swaps `action.yml` to the local `Dockerfile` so the release runs against current source — no more pinned-stale-image bootstrap trap.
2. **Auto-sync `action.yml`**: after each successful container build, `release-container.yml` opens a `ci:` PR that bumps `action.yml`'s image tag to the exact released version (e.g., `:2.99.0`). Consumers pinning to `@vX.Y.Z` get the matching image.

## Why

### Fix 1: release pipeline was hardcoded to a stale image

`release.yml:38-49` only swapped `action.yml` to the local `Dockerfile` on `pull_request` events. On push to main it fell through to the committed value: `image: 'docker://ghcr.io/quike/action-semantic-release:2.91'`. That image is pre-#133 code: it sees `preset: "custom"` in `.releaserc`, tries to `require('conventional-changelog-custom')`, and crashes.

Failing run: https://github.com/quike/action-semantic-release/actions/runs/26309318483/job/77453877691

The bootstrap trap is now resolved permanently — every release runs against the current source.

### Fix 2: `action.yml` has been silently drifting from published releases

`action.yml` was pinned to `:2.91` while the registry was on `:2.98.0`. Consumers using `quike/action-semantic-release@v2.98.0` were getting v2.91 *code* despite pinning to v2.98. No automation kept the file in sync.

The new `bump-action-image-tag` job in `release-container.yml` runs `needs: build-and-push-image` so it only fires after the image is successfully pushed. It updates `action.yml` to the exact released version and opens a `ci:` PR (which doesn't trigger another release, per `{ type: 'ci', release: false }` in `custom-release-rules.js`).

The bump PR is intentionally not auto-merged — a human reviews and merges. Multiple consecutive releases (e.g., from chore commits) will produce multiple bump PRs that will conflict on `action.yml`; merge the latest.

## Test plan

- [ ] Merge this PR.
- [ ] Verify the post-merge `Release` job in https://github.com/quike/action-semantic-release/actions uses `Dockerfile` (look for `Now action under test points to internal image.`).
- [ ] Verify a new release tag is cut (should be the first since main got stuck).
- [ ] Verify `release-container.yml` publishes the new image to ghcr.io.
- [ ] Verify the `bump-action-image-tag` job opens a new PR titled `ci: bump action.yml image to <version>`.
- [ ] Review and merge that auto-PR. Confirm `action.yml` on main now points at the matching tag.