### PR TITLE
fix(ci): use GITHUB_TOKEN for ghcr.io docker login

### DIFF
--- a/.github/workflows/release-container.yml
+++ b/.github/workflows/release-container.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GHTOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v6


### PR DESCRIPTION
## Summary

The docker login step in \`release-container.yml\` uses \`secrets.GHTOKEN\` (a fine-grained PAT) which doesn't include \`write:packages\` scope — fine-grained PATs don't expose that permission. This has been silently failing the container build for the last several releases (v2.97.0, v2.98.0, v3.0.0), leaving \`ghcr.io/quike/action-semantic-release\` stuck at the \`:2.91\` tag.

Switching docker login to \`secrets.GITHUB_TOKEN\`. The job already declares \`permissions.packages: write\` at the workflow level, so the auto-generated \`GITHUB_TOKEN\` has the correct scope without any token management overhead.

The \`bump-action-image-tag\` job keeps using \`GHTOKEN\` because PRs opened with \`GITHUB_TOKEN\` don't trigger downstream workflows — we want the bump PR to actually run CI.

## Failing run

https://github.com/quike/action-semantic-release/actions/runs/26317457710 — \`denied: permission_denied: The token provided does not match expected scopes.\`

## Test plan

- [ ] Merge.
- [ ] After merge, the next release-triggered \`Release Container\` workflow should succeed and push the v3.x image.
- [ ] The \`bump-action-image-tag\` job should then open a PR titled \`ci: bump action.yml image to <version>\`.
- [ ] Alternatively: re-run the failed v3.0.0 container workflow with \`gh run rerun 26317457710\` from main once this lands, to confirm without waiting for another release.