### PR TITLE
ci: bump action.yml image to 3.0.1

### DIFF
--- a/.github/workflows/release-container.yml
+++ b/.github/workflows/release-container.yml
@@ -84,7 +84,7 @@ jobs:
           echo "value=${VERSION}" >> "$GITHUB_OUTPUT"
       - name: Update action.yml
         run: |
-          yq -i ".runs.image = \"docker://${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.value }}\"" ./action.yml
+          sed -i "s|image: 'docker://[^']*'|image: 'docker://${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.value }}'|" ./action.yml
           grep "image:" ./action.yml
       - name: Open bump PR
         env:

--- a/action.yml
+++ b/action.yml
@@ -1,12 +1,17 @@
 name: 'action-semver'
 description: 'Github action to release projects using semantic-release'
 author: 'quike'
+
 branding:
   icon: share-2
   color: yellow
+
 inputs:
   dry-run:
-    description: 'The objective of the dry-run mode is to get a preview of the pending release. Dry-run mode skips the following steps: prepare, publish, addChannel, success and fail. In addition to this it prints the next version and release notes to the console.'
+    description:
+      'The objective of the dry-run mode is to get a preview of the pending release. Dry-run mode skips the following
+      steps: prepare, publish, addChannel, success and fail. In addition to this it prints the next version and release
+      notes to the console.'
     required: false
     default: 'false'
   working-path:
@@ -29,13 +34,18 @@ inputs:
     required: false
     default: 'true'
   default-preset-info:
-    description: 'Enables injection of the action''s opinionated presetConfig and releaseRules when a plugin entry declares preset: "custom". The action then swaps the preset back to "conventionalcommits" before semantic-release loads the parser. Any other preset value (conventionalcommits, angular, eslint, ember, …) is passed through to semantic-release untouched. See docs/FAQ.md for details on the "custom" preset policy.'
+    description:
+      'Enables injection of the action''s opinionated presetConfig and releaseRules when a plugin entry declares preset:
+      "custom". The action then swaps the preset back to "conventionalcommits" before semantic-release loads the parser.
+      Any other preset value (conventionalcommits, angular, eslint, ember, …) is passed through to semantic-release
+      untouched. See docs/FAQ.md for details on the "custom" preset policy.'
     required: false
     default: 'true'
   floating-tags:
     description: 'Create floating tags from major and minor versions after release.'
     required: false
     default: 'false'
+
 outputs:
   release-published:
     description: 'True if a new release is performed, false otherwise.'
@@ -53,6 +63,7 @@ outputs:
     description: 'SHA value associated to release commit.'
   release-git-tag:
     description: 'Git Tag associated to release commit.'
+
 runs:
   using: 'docker'
   image: 'docker://ghcr.io/quike/action-semantic-release:3.0.1'

--- a/action.yml
+++ b/action.yml
@@ -1,17 +1,12 @@
 name: 'action-semver'
 description: 'Github action to release projects using semantic-release'
 author: 'quike'
-
 branding:
   icon: share-2
   color: yellow
-
 inputs:
   dry-run:
-    description:
-      'The objective of the dry-run mode is to get a preview of the pending release. Dry-run mode skips the following
-      steps: prepare, publish, addChannel, success and fail. In addition to this it prints the next version and release
-      notes to the console.'
+    description: 'The objective of the dry-run mode is to get a preview of the pending release. Dry-run mode skips the following steps: prepare, publish, addChannel, success and fail. In addition to this it prints the next version and release notes to the console.'
     required: false
     default: 'false'
   working-path:
@@ -34,18 +29,13 @@ inputs:
     required: false
     default: 'true'
   default-preset-info:
-    description:
-      'Enables injection of the action''s opinionated presetConfig and releaseRules when a plugin entry declares preset:
-      "custom". The action then swaps the preset back to "conventionalcommits" before semantic-release loads the parser.
-      Any other preset value (conventionalcommits, angular, eslint, ember, …) is passed through to semantic-release
-      untouched. See docs/FAQ.md for details on the "custom" preset policy.'
+    description: 'Enables injection of the action''s opinionated presetConfig and releaseRules when a plugin entry declares preset: "custom". The action then swaps the preset back to "conventionalcommits" before semantic-release loads the parser. Any other preset value (conventionalcommits, angular, eslint, ember, …) is passed through to semantic-release untouched. See docs/FAQ.md for details on the "custom" preset policy.'
     required: false
     default: 'true'
   floating-tags:
     description: 'Create floating tags from major and minor versions after release.'
     required: false
     default: 'false'
-
 outputs:
   release-published:
     description: 'True if a new release is performed, false otherwise.'
@@ -63,10 +53,9 @@ outputs:
     description: 'SHA value associated to release commit.'
   release-git-tag:
     description: 'Git Tag associated to release commit.'
-
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/quike/action-semantic-release:2.91'
+  image: 'docker://ghcr.io/quike/action-semantic-release:3.0.1'
   env:
     DRY_RUN: ${{ inputs.dry-run }}
     DEBUG_MODE: ${{ inputs.debug-mode }}


### PR DESCRIPTION
Auto-generated after release `v3.0.1` to keep `action.yml` in sync with the published container image.