### PR TITLE
fix(src): address bugs in input handling, version parsing, and logging

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -63,6 +63,8 @@ outputs:
     description: 'SHA value associated to release commit.'
   release-git-tag:
     description: 'Git Tag associated to release commit.'
+  release-name:
+    description: 'Display name of the release (typically the version with optional prefix).'
 
 runs:
   using: 'docker'

--- a/src/main.js
+++ b/src/main.js
@@ -26,19 +26,17 @@ export async function run() {
 
     const options = await getOptions(config)
     const result = await runSemanticRelease(options, workDir)
-    if (result) {
-      const release = await verifyRelease(result)
-      if (release) {
-        let dryRunInput = getBooleanInput(INPUTS.DRY_RUN)
-        if (getBooleanInput(INPUTS.FLOATING_TAGS) && !dryRunInput) {
-          await setFloatingTags(release, { cwd: workDir, env: process.env })
-        }
-        if (getBooleanInput(INPUTS.ADD_SUMMARY) && !dryRunInput) {
-          await setSummary(release)
-        }
-      } else {
-        core.info('No release is published, stopping here.')
-      }
+    if (!result) {
+      core.info('No release is published, stopping here.')
+      return
+    }
+    const release = await verifyRelease(result)
+    const dryRunInput = getBooleanInput(INPUTS.DRY_RUN)
+    if (getBooleanInput(INPUTS.FLOATING_TAGS) && !dryRunInput) {
+      await setFloatingTags(release, { cwd: workDir, env: process.env })
+    }
+    if (getBooleanInput(INPUTS.ADD_SUMMARY) && !dryRunInput) {
+      await setSummary(release)
     }
   } catch (error) {
     console.error('Error executing action:', error)

--- a/src/set-floating-tags.js
+++ b/src/set-floating-tags.js
@@ -81,7 +81,7 @@ const createTag = async (myTag, gitHead, options) => {
 const setUp = async (options) => {
   const userName = getEnvVar('GIT_COMMITTER_NAME', DEFAULT_USER.USER_NAME)
   const userEmail = getEnvVar('GIT_COMMITTER_EMAIL', DEFAULT_USER.USER_EMAIL)
-  core.info(`Setting up env pre tagging with user: ${DEFAULT_USER.USER_NAME}`)
+  core.info(`Setting up env pre tagging with user: ${userName}`)
   try {
     await execa('git', ['config', 'user.name', userName], options)
     await execa('git', ['config', 'user.email', userEmail], options)

--- a/src/set-summary.js
+++ b/src/set-summary.js
@@ -19,7 +19,7 @@ This is the summary of the semantic-release-action.
   {{#if release.published}}
 | Version                 | Type                 | Tag                    | Git Head                |
 | ----------------------- | -------------------- | ---------------------- | ----------------------- |
-| {{release.new.version}} | \` {{release.new.type}} \` | {{release.new.gitTag}} | \`{{release.new.gitHead}}\` |
+| {{release.new.version}} | \`{{release.new.type}}\` | {{release.new.gitTag}} | \`{{release.new.gitHead}}\` |
 
 ### Notes
 <details><summary>Notes</summary>{{release.new.notes}}</details>
@@ -34,7 +34,7 @@ This is the summary of the semantic-release-action.
 {{#if release.last}}
 | Version                 | Type                 | Tag                    | Git Head                |
 | ----------------------- | -------------------- | ---------------------- | ----------------------- |
-| {{release.last.version}} | \`{{default (release.last.type) "none"}} \` | {{release.last.gitTag}} | \`{{release.last.gitHead}} \`|
+| {{release.last.version}} | \`{{default (release.last.type) "none"}}\` | {{release.last.gitTag}} | \`{{release.last.gitHead}}\` |
 {{else}}
 No previous release found.
 {{/if}}

--- a/src/utils.js
+++ b/src/utils.js
@@ -49,14 +49,23 @@ export const cleanObject = (obj) => {
 /**
  * Retrieves a boolean input value from the GitHub Actions input.
  *
+ * When the input is unset or empty, returns the configured default instead of
+ * letting `core.getBooleanInput` throw (it requires a valid boolean literal).
+ *
  * @param {*} config - The name of the input to retrieve.
  * @returns {boolean} - The boolean value of the input.
  */
 export const getBooleanInput = (config) => {
   const { name, required, default: defaultValue } = config
-  const input = core.getBooleanInput(isGitLabCi() ? transformKey(name) : name, { required })
-  core.info(`${name}: ${input}`)
-  return input !== undefined ? input : defaultValue
+  const inputName = isGitLabCi() ? transformKey(name) : name
+  const rawValue = core.getInput(inputName, { required })
+  if (rawValue === '' || rawValue === undefined) {
+    core.info(`${name}: (using default) ${defaultValue}`)
+    return defaultValue
+  }
+  const value = core.getBooleanInput(inputName, { required })
+  core.info(`${name}: ${value}`)
+  return value
 }
 
 /**

--- a/src/verify-release.js
+++ b/src/verify-release.js
@@ -18,10 +18,11 @@ export const verifyRelease = async (result) => {
   core.info(`Release ${nextRelease.type} with Version ${nextRelease.version}`)
 
   const { version, notes, type, channel, gitHead, gitTag, name } = nextRelease
-  const [major, minor, patch] = version.split('.')
+  const versionParts = /^(\d+)\.(\d+)\.(\d+)/.exec(version) || []
+  const [, major, minor, patch] = versionParts
 
   const release = {
-    published: nextRelease !== undefined,
+    published: true,
     last: {
       version: lastRelease.version !== undefined ? lastRelease.version : '',
       gitHead: lastRelease.gitHead !== undefined ? lastRelease.gitHead : '',

--- a/test/get-config.test.js
+++ b/test/get-config.test.js
@@ -9,6 +9,7 @@ vi.mock('@actions/core', async () => {
   const original = await vi.importActual('@actions/core')
   return {
     ...original,
+    getInput: vi.fn().mockReturnValue('placeholder'),
     getBooleanInput: vi.fn()
   }
 })

--- a/test/get-plugins.test.js
+++ b/test/get-plugins.test.js
@@ -6,6 +6,7 @@ vi.mock('@actions/core', async () => {
   const original = await vi.importActual('@actions/core')
   return {
     ...original,
+    getInput: vi.fn().mockReturnValue('placeholder'),
     getBooleanInput: vi.fn()
   }
 })

--- a/test/preset-integration.test.js
+++ b/test/preset-integration.test.js
@@ -7,6 +7,7 @@ vi.mock('@actions/core', async () => {
   const original = await vi.importActual('@actions/core')
   return {
     ...original,
+    getInput: vi.fn().mockReturnValue('placeholder'),
     getBooleanInput: vi.fn()
   }
 })

--- a/test/set-floating-tags.test.js
+++ b/test/set-floating-tags.test.js
@@ -9,7 +9,7 @@ vi.mock('execa')
 
 describe('setFloatingTags', () => {
   beforeEach(() => {
-    vi.clearAllMocks()
+    vi.resetAllMocks()
   })
 
   afterEach(() => {
@@ -156,12 +156,12 @@ describe('setFloatingTags', () => {
 
     const result = await setFloatingTags(release, { env: process.env })
 
-    expect(core.info).toHaveBeenCalledWith('Setting up env pre tagging with user: ' + DEFAULT_USER.USER_NAME)
-    expect(execa).toHaveBeenCalledWith('git', ['config', 'user.name', 'custom.user'], {
+    expect(core.info).toHaveBeenCalledWith('Setting up env pre tagging with user: ' + user.GIT_COMMITTER_NAME)
+    expect(execa).toHaveBeenCalledWith('git', ['config', 'user.name', user.GIT_COMMITTER_NAME], {
       cwd: process.cwd(),
       env: process.env
     })
-    expect(execa).toHaveBeenCalledWith('git', ['config', 'user.email', 'custom.user@example.com'], {
+    expect(execa).toHaveBeenCalledWith('git', ['config', 'user.email', user.GIT_COMMITTER_EMAIL], {
       cwd: process.cwd(),
       env: process.env
     })

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -130,32 +130,55 @@ describe('getBooleanInput', () => {
   })
 
   it('should return the boolean input when provided', () => {
+    core.getInput.mockReturnValue('true')
     core.getBooleanInput.mockReturnValue(true)
 
     const result = getBooleanInput(INPUTS.DRY_RUN)
 
+    expect(core.getInput).toHaveBeenCalledWith('dry-run', { required: false })
     expect(core.getBooleanInput).toHaveBeenCalledWith('dry-run', { required: false })
     expect(core.info).toHaveBeenCalledWith('dry-run: true')
     expect(result).toBe(true)
   })
 
-  it('should return the default value when input is undefined', () => {
-    core.getBooleanInput.mockReturnValue(undefined)
+  it('should return the configured default when the env var is empty', () => {
+    core.getInput.mockReturnValue('')
 
     const result = getBooleanInput(INPUTS.DRY_RUN)
 
-    expect(core.getBooleanInput).toHaveBeenCalledWith('dry-run', { required: false })
-    expect(core.info).toHaveBeenCalledWith('dry-run: undefined')
+    expect(core.getInput).toHaveBeenCalledWith('dry-run', { required: false })
+    expect(core.getBooleanInput).not.toHaveBeenCalled()
+    expect(core.info).toHaveBeenCalledWith('dry-run: (using default) false')
     expect(result).toBe(false)
+  })
+
+  it('should return the configured default when the env var is undefined', () => {
+    core.getInput.mockReturnValue(undefined)
+
+    const result = getBooleanInput(INPUTS.DRY_RUN)
+
+    expect(core.getBooleanInput).not.toHaveBeenCalled()
+    expect(result).toBe(false)
+  })
+
+  it('should not swallow malformed boolean values', () => {
+    core.getInput.mockReturnValue('yes')
+    core.getBooleanInput.mockImplementation(() => {
+      throw new TypeError('Input does not meet YAML 1.2 "Core Schema" specification.')
+    })
+
+    expect(() => getBooleanInput(INPUTS.DRY_RUN)).toThrow(/YAML 1.2/)
   })
 
   it('should return the boolean value when input is provided and CI is GitLab', () => {
     process.env.CI = 'true'
     process.env.GITLAB_CI = 'true'
+    core.getInput.mockReturnValue('true')
     core.getBooleanInput.mockReturnValue(true)
 
     const result = getBooleanInput(INPUTS.DEBUG_MODE)
 
+    expect(core.getInput).toHaveBeenCalledWith('DEBUG_MODE', { required: false })
     expect(core.getBooleanInput).toHaveBeenCalledWith('DEBUG_MODE', { required: false })
     expect(core.info).toHaveBeenCalledWith('debug-mode: true')
     expect(result).toBe(true)

--- a/test/verify-release.test.js
+++ b/test/verify-release.test.js
@@ -56,4 +56,48 @@ describe('verifyRelease', () => {
     expect(core.setOutput).toHaveBeenCalledWith('release-git-tag', 'v1.2.3')
     expect(core.setOutput).toHaveBeenCalledWith('release-name', 'Release 1.2.3')
   })
+
+  it('should strip pre-release suffix from major/minor/patch outputs', async () => {
+    const result = {
+      lastRelease: { version: '1.2.2', gitHead: 'def', gitTag: 'v1.2.2' },
+      nextRelease: {
+        version: '2.0.0-beta.1',
+        notes: '',
+        type: 'major',
+        channel: 'beta',
+        gitHead: 'abc',
+        gitTag: 'v2.0.0-beta.1',
+        name: 'v2.0.0-beta.1'
+      },
+      commits: []
+    }
+
+    await verifyRelease(result)
+
+    expect(core.exportVariable).toHaveBeenCalledWith('RELEASE_VERSION', '2.0.0-beta.1')
+    expect(core.exportVariable).toHaveBeenCalledWith('RELEASE_MAJOR', '2')
+    expect(core.exportVariable).toHaveBeenCalledWith('RELEASE_MINOR', '0')
+    expect(core.exportVariable).toHaveBeenCalledWith('RELEASE_PATCH', '0')
+  })
+
+  it('should always export release-published as true (function is only called when a release exists)', async () => {
+    const result = {
+      lastRelease: { version: '1.0.0', gitHead: 'old', gitTag: 'v1.0.0' },
+      nextRelease: {
+        version: '1.0.1',
+        notes: '',
+        type: 'patch',
+        channel: 'stable',
+        gitHead: 'new',
+        gitTag: 'v1.0.1',
+        name: 'v1.0.1'
+      },
+      commits: []
+    }
+
+    const release = await verifyRelease(result)
+
+    expect(release.published).toBe(true)
+    expect(core.exportVariable).toHaveBeenCalledWith('RELEASE_PUBLISHED', true)
+  })
 })


### PR DESCRIPTION
## Summary

Six bug fixes across `src/` and one in `action.yml`, plus repair of the long-standing failing `set-floating-tags` test (turned out to be a mock-leak, not a code issue).

## Bugs fixed

| # | Bug | Where | Fix |
|---|---|---|---|
| 1 | `getBooleanInput` threw on empty input instead of falling back to its configured default | `src/utils.js` | Check `core.getInput` first; only call `core.getBooleanInput` when a non-empty value is present. |
| 2 | Dead `else` branch in `main.js` — `verifyRelease` never returns falsy | `src/main.js` | Removed dead branch; the "no release" log now lives on the only real no-release code path. |
| 3 | `release-name` output exported by code but not declared in `action.yml` | `action.yml` | Added the missing `outputs.release-name` declaration. |
| 4 | `setUp` logged `DEFAULT_USER.USER_NAME` regardless of overrides | `src/set-floating-tags.js` | Log the resolved `userName` (the value actually used by `git config`). |
| 6 | Pre-release versions like `2.0.0-beta.1` mangled `major/minor/patch` outputs (`patch: "0-beta"`) | `src/verify-release.js` | Use a numeric-prefix regex to extract only the semver core. |
| 11 | `published: nextRelease !== undefined` was always `true` at the point we evaluated it | `src/verify-release.js` | Simplified to `published: true`. |
| 12 | Stray spaces inside backticks in the summary template | `src/set-summary.js` | Removed the spaces; cosmetic. |

## Test repair (was PR 2 — folded in)

The failing `should use user and email from env for git config` test in `test/set-floating-tags.test.js` was actually a **mock-leak**: prior tests called `execa.mockImplementation(...)`, and `vi.clearAllMocks()` in `beforeEach` only clears call history — it does **not** reset implementations. So the last test's "throw on any `git config`" implementation leaked into the next test, causing the second `setUp` execa call (for `user.email`) to never execute and breaking the assertion. Switching to `vi.resetAllMocks()` fixes the leak.

## New tests added

- `test/utils.test.js`: 4 cases for `getBooleanInput` covering the new fallback path (empty input → default, undefined → default, malformed value still throws, GitLab-CI key transform).
- `test/verify-release.test.js`: pre-release version stripping (`2.0.0-beta.1` → major/minor/patch correct), and `published: true` invariant.
- Existing `set-floating-tags` test that asserted `'Setting up env pre tagging with user: …'` updated to the corrected value.

Several other tests (get-plugins, get-config, preset-integration) needed their `@actions/core` mock to add a stub for `getInput` since the new `getBooleanInput` consults it first.

## Verification

```
npx vitest run
# Test Files  11 passed (11)
# Tests       129 passed (129)
```

No more pre-existing failure on `main`.
