### PR TITLE
fix(ci,src): update auto-bump PR in place, fail-fast on real tag-delete errors

### DIFF
--- a/.github/workflows/release-container.yml
+++ b/.github/workflows/release-container.yml
@@ -86,6 +86,25 @@ jobs:
         run: |
           sed -i "s|image: 'docker://[^']*'|image: 'docker://${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.value }}'|" ./action.yml
           grep "image:" ./action.yml
+      - name: Close stale bump PRs
+        env:
+          GH_TOKEN: ${{ secrets.GHTOKEN }}
+        run: |
+          # Multiple releases (e.g., back-to-back chore commits) can each spawn
+          # a bump PR. They all touch the same line in action.yml, so they'd
+          # conflict. Close any still-open bump PRs before opening the new one
+          # — only the latest version's PR is meaningful.
+          stale=$(gh pr list \
+            --state open \
+            --search 'in:title "ci: bump action.yml image to"' \
+            --json number \
+            --jq '.[].number')
+          for number in $stale; do
+            echo "Closing superseded bump PR #${number}"
+            gh pr close "$number" \
+              --delete-branch \
+              --comment "Superseded by release v${{ steps.version.outputs.value }}."
+          done
       - name: Open bump PR
         env:
           GH_TOKEN: ${{ secrets.GHTOKEN }}

--- a/.github/workflows/release-container.yml
+++ b/.github/workflows/release-container.yml
@@ -82,42 +82,40 @@ jobs:
           TAG_NAME="${{ github.event.release.tag_name }}"
           VERSION="${TAG_NAME#v}"
           echo "value=${VERSION}" >> "$GITHUB_OUTPUT"
-      - name: Update action.yml
-        run: |
-          sed -i "s|image: 'docker://[^']*'|image: 'docker://${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.value }}'|" ./action.yml
-          grep "image:" ./action.yml
-      - name: Close stale bump PRs
+      - name: Update or open bump PR
         env:
           GH_TOKEN: ${{ secrets.GHTOKEN }}
         run: |
-          # Multiple releases (e.g., back-to-back chore commits) can each spawn
-          # a bump PR. They all touch the same line in action.yml, so they'd
-          # conflict. Close any still-open bump PRs before opening the new one
-          # — only the latest version's PR is meaningful.
-          stale=$(gh pr list \
-            --state open \
-            --search 'in:title "ci: bump action.yml image to"' \
-            --json number \
-            --jq '.[].number')
-          for number in $stale; do
-            echo "Closing superseded bump PR #${number}"
-            gh pr close "$number" \
-              --delete-branch \
-              --comment "Superseded by release v${{ steps.version.outputs.value }}."
-          done
-      - name: Open bump PR
-        env:
-          GH_TOKEN: ${{ secrets.GHTOKEN }}
-        run: |
-          BRANCH="ci/bump-action-image-${{ steps.version.outputs.value }}"
+          # Renovate/Dependabot-style update-in-place: one canonical branch and
+          # PR for the bump, force-pushed and re-titled on each release. Avoids
+          # piling up duplicate PRs when several releases land back-to-back.
+          BRANCH="ci/bump-action-image"
+          VERSION="${{ steps.version.outputs.value }}"
+          TITLE="ci: bump action.yml image to ${VERSION}"
+          BODY="Auto-generated after release \`v${VERSION}\` to keep \`action.yml\` in sync with the published container image. This PR is updated in place by the release pipeline; force-pushes will overwrite manual changes."
+
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git checkout -b "$BRANCH"
+
+          # Reset the bump branch to the tip of main and re-apply the image update.
+          git checkout -B "${BRANCH}"
+          sed -i "s|image: 'docker://[^']*'|image: 'docker://${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${VERSION}'|" ./action.yml
+          grep "image:" ./action.yml
+
+          if git diff --quiet -- action.yml; then
+            echo "action.yml already at ${VERSION} on main; nothing to bump."
+            exit 0
+          fi
+
           git add action.yml
-          git commit -m "ci: bump action.yml image to ${{ steps.version.outputs.value }}"
-          git push origin "$BRANCH"
-          gh pr create \
-            --base main \
-            --head "$BRANCH" \
-            --title "ci: bump action.yml image to ${{ steps.version.outputs.value }}" \
-            --body "Auto-generated after release \`v${{ steps.version.outputs.value }}\` to keep \`action.yml\` in sync with the published container image."
+          git commit -m "${TITLE}"
+          git push --force-with-lease origin "${BRANCH}"
+
+          existing=$(gh pr list --head "${BRANCH}" --state open --json number --jq '.[0].number // empty')
+          if [ -n "${existing}" ]; then
+            echo "Updating existing PR #${existing}"
+            gh pr edit "${existing}" --title "${TITLE}" --body "${BODY}"
+          else
+            echo "Opening new bump PR"
+            gh pr create --base main --head "${BRANCH}" --title "${TITLE}" --body "${BODY}"
+          fi

--- a/src/set-floating-tags.js
+++ b/src/set-floating-tags.js
@@ -32,7 +32,21 @@ export const setFloatingTags = async (release, { cwd = process.cwd(), env = proc
 }
 
 /**
- * Deletes a Git tag both locally and remotely.
+ * Detects whether an execa error is a benign "tag does not exist" failure that
+ * can be safely ignored (common on the first release of a major/minor floating tag).
+ *
+ * @param {Error} error
+ * @returns {boolean}
+ */
+const isMissingTagError = (error) => {
+  const message = String(error?.stderr ?? '') + ' ' + String(error?.message ?? '')
+  return /tag '[^']*' not found|remote ref does not exist/i.test(message)
+}
+
+/**
+ * Deletes a Git tag both locally and remotely. Silently tolerates "tag does not
+ * exist" failures (first-release case); rethrows any other error so the action
+ * fails fast instead of masking real problems.
  *
  * @param {string} myTag - The name of the tag to delete.
  * @param {Object} options - Options for deleting the tag.
@@ -44,9 +58,15 @@ const deleteTag = async (myTag, options) => {
   core.info(`Deleting tag: ${myTag}`)
   try {
     await execa('git', ['tag', myTag, '-d'], options)
+  } catch (error) {
+    if (!isMissingTagError(error)) throw error
+    core.info(`Local tag '${myTag}' did not exist; skipping local delete.`)
+  }
+  try {
     await execa('git', ['push', 'origin', '--delete', myTag], options)
   } catch (error) {
-    core.error(`Unable to delete tag. Error: ${error}`)
+    if (!isMissingTagError(error)) throw error
+    core.info(`Remote tag '${myTag}' did not exist; skipping remote delete.`)
   }
 }
 

--- a/test/set-floating-tags.test.js
+++ b/test/set-floating-tags.test.js
@@ -60,7 +60,7 @@ describe('setFloatingTags', () => {
     expect(result).toEqual({})
   })
 
-  it('should capture an error when a tag cannot be deleted', async () => {
+  it('should propagate a non-missing-tag delete error', async () => {
     const release = {
       new: {
         major: 1,
@@ -69,19 +69,64 @@ describe('setFloatingTags', () => {
       }
     }
 
-    // Mock `execa` to throw an error when deleting a tag
     execa.mockImplementation((command, args) => {
       if (command === 'git' && args.includes('-d')) {
-        throw new Error('Failed to delete tag')
+        const err = new Error('fatal: unable to access remote: Permission denied')
+        err.stderr = 'fatal: Permission denied'
+        throw err
+      }
+      return Promise.resolve()
+    })
+
+    await expect(setFloatingTags(release, {})).rejects.toThrow(/Permission denied/)
+  })
+
+  it('should swallow a "tag not found" delete error (first-release case)', async () => {
+    const release = {
+      new: {
+        major: 3,
+        minor: 0,
+        gitHead: 'abc123'
+      }
+    }
+
+    execa.mockImplementation((command, args) => {
+      if (command === 'git' && args.includes('-d')) {
+        const err = new Error("error: tag 'v3' not found.")
+        err.stderr = "error: tag 'v3' not found."
+        throw err
       }
       return Promise.resolve()
     })
 
     const result = await setFloatingTags(release, {})
 
-    expect(core.error).toHaveBeenCalledWith('Unable to delete tag. Error: Error: Failed to delete tag')
-    expect(core.info).toHaveBeenCalledWith('Setting up env pre tagging with user: ' + DEFAULT_USER.USER_NAME)
-    expect(result).toEqual({ majorTag: 'v1', minorTag: 'v1.0' })
+    expect(core.info).toHaveBeenCalledWith(expect.stringMatching(/did not exist; skipping local delete/))
+    expect(result).toEqual({ majorTag: 'v3', minorTag: 'v3.0' })
+  })
+
+  it('should swallow a "remote ref does not exist" push-delete error', async () => {
+    const release = {
+      new: {
+        major: 3,
+        minor: 0,
+        gitHead: 'abc123'
+      }
+    }
+
+    execa.mockImplementation((command, args) => {
+      if (command === 'git' && args.includes('--delete')) {
+        const err = new Error('remote ref does not exist')
+        err.stderr = 'error: unable to delete v3: remote ref does not exist'
+        throw err
+      }
+      return Promise.resolve()
+    })
+
+    const result = await setFloatingTags(release, {})
+
+    expect(core.info).toHaveBeenCalledWith(expect.stringMatching(/did not exist; skipping remote delete/))
+    expect(result).toEqual({ majorTag: 'v3', minorTag: 'v3.0' })
   })
 
   it('should capture an error when a tag cannot be created', async () => {


### PR DESCRIPTION
## Summary

Two related robustness fixes:

1. **Auto-bump uses Renovate/Dependabot-style update-in-place.** One canonical `ci/bump-action-image` branch and one PR. Each release force-pushes the latest image-tag commit and edits the PR title/body. Back-to-back releases no longer pile up duplicate PRs; manual review history stays on a single PR.
2. **`deleteTag` no longer swallows real errors.** Previously every error from `git tag -d` / `git push --delete` was caught and logged, including network failures and permission errors. Now only "tag does not exist" failures (the legitimate first-release case) are swallowed; everything else propagates and fails the action loudly.

## Why

### Item 1

After PR #134, the auto-bump workflow opens a PR after each release. Under the artifact-identity `chore: minor` policy documented in FAQ, several consecutive merges can each cut a release. Earlier iteration of this PR closed stale bump PRs to prevent conflicts; that worked but created PR noise (closed PRs accumulating in history) and lost any review comments. The Renovate-style update-in-place pattern is cleaner:

- Branch name is fixed (`ci/bump-action-image`, no version suffix).
- Each release run resets the branch to the tip of main, re-applies the image-tag sed, and force-pushes.
- If a PR is already open for that branch, `gh pr edit` updates its title and body to reflect the new version.
- If not, `gh pr create` opens one.
- If `action.yml` on main already matches the released version (e.g., the bump PR was merged between two release events), the step exits early with no commit.

### Item 2

We saw the failure mode live in https://github.com/quike/action-semantic-release/actions/runs/26317419350 — the v3.0.0 release tried to delete floating tags `v3` and `v3.0` that didn't exist yet (first time we cut a v3 major), and the existing catch-all silently turned the errors into warnings. That was *intentional* for first-release, but the same code path would silently eat a permission error, network failure, or stale credential — leaving the action green when something real was broken.

The fix discriminates: `isMissingTagError(error)` matches stderr / message against the well-known git error patterns (`tag '…' not found` / `remote ref does not exist`); any other failure rethrows.

## Tests

- **New cases in `test/set-floating-tags.test.js`:**
  - "should propagate a non-missing-tag delete error" — verifies `Permission denied` bubbles up via `.rejects.toThrow`.
  - "should swallow a 'tag not found' delete error (first-release case)" — verifies the benign first-release path stays silent and the function still returns the tag pair.
  - "should swallow a 'remote ref does not exist' push-delete error" — same, for the remote-side case.
- The pre-existing "should capture an error when a tag cannot be deleted" was replaced — its assumption (all errors swallowed) is no longer the contract.
- Same `vi.resetAllMocks()` / username-assertion fixes from #138 are applied here too so this PR's CI is independently green. Will rebase cleanly against #138 in either order.

## Verification

```
npx vitest run
# Test Files  11 passed (11)
# Tests       127 passed (127)
```

## Follow-up not in this PR

`createTag` has the same swallow-all pattern as the old `deleteTag` but the failure modes don't have a benign "already exists" equivalent (git tag creation always fails loudly when the SHA is missing). Leaving as-is for now; tracked mentally for a future tightening pass.
