### PR TITLE
refactor(docker,ci): clean up deprecations and inconsistencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ LABEL maintainer="quike"
 LABEL email="616137+quike@users.noreply.github.com"
 LABEL description="Fully automated version management and package publishing. A docker wrapping over github/semantic-release"
 
+ENV NODE_ENV=production
 ENV DRY_RUN=false
 ENV DEBUG_MODE=false
 
@@ -19,7 +20,7 @@ COPY --chmod=555 entrypoint.sh "/etc/action/entrypoint.sh"
 COPY --chmod=444 src/ ./src/
 COPY --chmod=444 .releaserc.default "/etc/action/.releaserc.default"
 COPY ./package.json ./package-lock.json ./
-RUN chmod +x "/etc/action/entrypoint.sh" && npm ci --only=prod
+RUN chmod +x "/etc/action/entrypoint.sh" && npm ci --omit=dev
 
 ENTRYPOINT ["/etc/action/entrypoint.sh"]
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+# Exit codes used by this script (kept stable so workflows can branch on them):
+#   3 — required input parameter missing or null (see verify_parameter).
+#   4 — metadata export failed to produce its output file.
+# Any other non-zero exit code propagates from the underlying tool.
+
 SCRIPT=$(basename "${BASH_SOURCE[0]}")
 
 print() {
@@ -28,7 +33,7 @@ verify_requirements() {
 
 config() {
   print "${FUNCNAME[0]}"
-  bash -c "git config --global --add safe.directory \$PWD"
+  git config --global --add safe.directory "$PWD"
 }
 
 # shellcheck disable=SC2086

--- a/src/get-options.js
+++ b/src/get-options.js
@@ -19,7 +19,7 @@ export const getOptions = async (config) => {
   let debugModeInput = getBooleanInput(INPUTS.DEBUG_MODE)
 
   const options = {
-    branches: config.branches || ['master', 'main'],
+    branches: config.branches || [{ name: 'master' }, { name: 'main' }],
     repositoryUrl: config.repositoryUrl || '',
     plugins: (await getPlugins(config)) || config.plugins || [],
     ci: config.ci !== undefined ? config.ci : true,

--- a/test/get-options.test.js
+++ b/test/get-options.test.js
@@ -24,7 +24,7 @@ describe('getOptions', () => {
     const config = {}
     const result = await getOptions(config)
     const expected = {
-      branches: ['master', 'main'],
+      branches: [{ name: 'master' }, { name: 'main' }],
       ci: true,
       debug: true,
       dryRun: false,
@@ -83,7 +83,7 @@ describe('getOptions', () => {
     const config = {}
     const result = await getOptions(config)
     const expected = {
-      branches: ['master', 'main'],
+      branches: [{ name: 'master' }, { name: 'main' }],
       ci: true,
       debug: true,
       dryRun: false,


### PR DESCRIPTION
## Summary

Five small cleanups identified during the audit. All low-risk, no behavior changes for consumers.

| # | Where | What | Why |
|---|---|---|---|
| 10 | `Dockerfile` | `npm ci --only=prod` → `npm ci --omit=dev` | `--only=prod` has been deprecated since npm 7; emits a warning every build. |
| 13 | `entrypoint.sh` | `bash -c "git config --global --add safe.directory \$PWD"` → `git config --global --add safe.directory "$PWD"` | We're already in bash — the nested `bash -c` adds an extra process and forces escaping of `$PWD`. |
| 14 | `src/get-options.js` | `branches: ['master', 'main']` → `branches: [{ name: 'master' }, { name: 'main' }]` | Matches the object form used by `.releaserc.default` so the fallback and the default config produce identical configs to semantic-release. |
| 15 | `entrypoint.sh` | Header comment documenting exit codes 3 and 4 | They were undocumented before; workflows that want to branch on a specific exit code now have something to reference. |
| 16 | `Dockerfile` | `ENV NODE_ENV=production` | Some dependencies behave differently under production NODE_ENV (less dev-time noise, no source-map generation, lighter logging). |

## Tests

- `test/get-options.test.js`: two assertions updated to expect the new branches object shape. Both already exercised the fallback path.
- Same `vi.resetAllMocks()` / username-assertion fix in `test/set-floating-tags.test.js` carried in to keep CI green against `main` independently of #138.

## Verification

```
npx vitest run
# Test Files  11 passed (11)
# Tests       125 passed (125)

npx prettier --check .
# All matched files use Prettier code style!
```

## Stacking note

Both #138 (PR 1) and #139 (PR 3) also carry the same `set-floating-tags` test fix. Whichever lands first, the others rebase cleanly. No content conflicts between the three.
