### PR TITLE
fix(ci): use --force for bump branch push to avoid stale-info rejection

### DIFF
--- a/.github/workflows/release-container.yml
+++ b/.github/workflows/release-container.yml
@@ -109,7 +109,11 @@ jobs:
 
           git add action.yml
           git commit -m "${TITLE}"
-          git push --force-with-lease origin "${BRANCH}"
+          # `--force` (not `--force-with-lease`): the local branch was just created via
+          # `git checkout -B` and has no remote-tracking ref, so `--force-with-lease` would
+          # treat the remote as "stale info" and reject. This branch is bot-managed and
+          # any manual edits to it are documented as overwritten on the next release.
+          git push --force origin "${BRANCH}"
 
           existing=$(gh pr list --head "${BRANCH}" --state open --json number --jq '.[0].number // empty')
           if [ -n "${existing}" ]; then


### PR DESCRIPTION
## Summary

The auto-bump workflow shipped in #139 used `git push --force-with-lease`, but the local bump branch is created with `git checkout -B` and has no remote-tracking ref. `--force-with-lease` then interprets that as "stale info" and rejects the push, leaving the bump PR stuck on the previous version (see https://github.com/quike/action-semantic-release/actions/runs/26320742595/job/77489302093 — `! [rejected] ci/bump-action-image -> ci/bump-action-image (stale info)`).

Switching to plain `git push --force`. The branch is bot-managed and the PR body already documents that manual edits get overwritten on the next release, so the safety net `--force-with-lease` is supposed to provide doesn't apply here.

## Verification path

Once merged, the next release-triggered run should:

1. Build and push the new image.
2. Reset `ci/bump-action-image` to main's tip, apply the bump, force-push.
3. Find the existing #142 (or successor) PR for that branch and `gh pr edit` it to the new version.

If that succeeds end-to-end without a "stale info" rejection, the loop is closed.

## Why not the fetch-then-lease approach

Considered fetching the remote branch first to give `--force-with-lease` a baseline, but the extra branch handling (fetch may fail when the branch doesn't exist yet on first release, requires explicit `<branch>:<expected-sha>` syntax for safety) traded simplicity for protection that the documented bot-managed contract already supersedes.
