### PR TITLE
fix(entrypoint): emit action.yml output names in PR mode

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -51,8 +51,12 @@ run() {
 
 validate() {
   CURRENT_SHA=$(git rev-parse HEAD)
-  echo "GIT_HEAD=${CURRENT_SHA}" >>"$GITHUB_OUTPUT"
+  # Env vars use the UPPERCASE_UNDERSCORE convention (in-job, subsequent steps).
+  # Step outputs must use the hyphenated names declared in action.yml so that
+  # `steps.<id>.outputs.release-git-head` resolves — the JS path (verify-release.js)
+  # already emits those names for the release case; this mirrors them for PR mode.
   echo "GIT_HEAD=${CURRENT_SHA}" >>"$GITHUB_ENV"
+  echo "release-git-head=${CURRENT_SHA}" >>"$GITHUB_OUTPUT"
   if [ -n "$EVENT_NAME" ] && [ "$EVENT_NAME" == "pull_request" ]; then
     print "Type of event: $EVENT_NAME"
     if [ -f "$GITHUB_EVENT_PATH" ]; then
@@ -71,8 +75,8 @@ validate() {
     print "HEAD is now at ${CURRENT_SHA} after Pull Request Commit Id merge with HEAD."
     PULL_REQUEST_VERSION=${ORIGINAL_SHA:0:7}
     print "Short SHA=${PULL_REQUEST_VERSION}"
-    echo "RELEASE_VERSION=${PULL_REQUEST_VERSION}" >>"$GITHUB_OUTPUT"
     echo "RELEASE_VERSION=${PULL_REQUEST_VERSION}" >>"$GITHUB_ENV"
+    echo "release-version=${PULL_REQUEST_VERSION}" >>"$GITHUB_OUTPUT"
   fi
 }
 


### PR DESCRIPTION
## Summary

In PR mode the action's `release-version` and `release-git-head` outputs were always empty, even though the entrypoint computed the values. Root cause: `validate()` wrote them to `$GITHUB_OUTPUT` under env-style names (`RELEASE_VERSION`, `GIT_HEAD`) that don't match the hyphenated names declared in `action.yml` (`release-version`, `release-git-head`). Consumers reading `steps.<id>.outputs.release-version` got nothing.

## Why it only affected PR mode

- **Release mode**: semantic-release publishes → `verify-release.js` runs → it emits outputs as `release-version`, `release-git-head`, etc. (lowercase-hyphen, matching `action.yml`). Works.
- **PR mode**: semantic-release publishes nothing → `runSemanticRelease` returns `null` → `main.js` returns early *before* `verifyRelease`. So JS only sets `release-published: false`. The entrypoint's `validate()` is the only thing providing a PR "version" (the short SHA), but it wrote the wrong output names.

## Change

`entrypoint.sh` `validate()` now writes:

- Env vars keep the `UPPERCASE_UNDERSCORE` convention (`GIT_HEAD`, `RELEASE_VERSION`) for in-job subsequent steps.
- Step outputs use the **declared** hyphenated names (`release-git-head`, `release-version`) so `steps.<id>.outputs.*` resolves.

Other `release-*` outputs (`release-major/minor/patch/type`) are intentionally left unset in PR mode — there's no real release, so downstream should gate on `release-published` rather than parse a non-existent version.

`shellcheck entrypoint.sh` passes clean.

## Note on cross-job usage (not fixable here)

`GITHUB_ENV` is job-scoped and never crosses jobs by design. To consume the PR version in a downstream job, the *consuming workflow* must surface the step output as a job output and read it via `needs`:

```yaml
jobs:
  release:
    outputs:
      version: ${{ steps.release.outputs.release-version }}
  deploy:
    needs: release
    steps:
      - run: echo "${{ needs.release.outputs.version }}"
```
