### PR TITLE
ci: bump action.yml image to 3.1.0

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -68,7 +68,7 @@ outputs:
 
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/quike/action-semantic-release:3.0.6'
+  image: 'docker://ghcr.io/quike/action-semantic-release:3.1.0'
   env:
     DRY_RUN: ${{ inputs.dry-run }}
     DEBUG_MODE: ${{ inputs.debug-mode }}


### PR DESCRIPTION
Auto-generated after release `v3.1.0` to keep `action.yml` in sync with the published container image. This PR is updated in place by the release pipeline; force-pushes will overwrite manual changes.