### PR TITLE
ci: bump action.yml image to 3.4.0

### DIFF
--- a/.releaserc.default
+++ b/.releaserc.default
@@ -5,10 +5,10 @@
   ],
   "plugins": [
     ["@semantic-release/commit-analyzer", {
-      "preset": "custom"
+      "preset": "conventionalcommits"
     }],
     ["@semantic-release/release-notes-generator", {
-      "preset": "custom"
+      "preset": "conventionalcommits"
     }],
     "@semantic-release/git"
   ],

--- a/action.yml
+++ b/action.yml
@@ -68,7 +68,7 @@ outputs:
 
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/quike/action-semantic-release:3.3.0'
+  image: 'docker://ghcr.io/quike/action-semantic-release:3.4.0'
   env:
     DRY_RUN: ${{ inputs.dry-run }}
     DEBUG_MODE: ${{ inputs.debug-mode }}


### PR DESCRIPTION
Auto-generated after release `v3.4.0` to keep `action.yml` in sync with the published container image. This PR is updated in place by the release pipeline; force-pushes will overwrite manual changes.