### PR TITLE
ci: bump action.yml image to 3.7.0

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -68,7 +68,7 @@ outputs:
 
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/quike/action-semantic-release:3.5.0'
+  image: 'docker://ghcr.io/quike/action-semantic-release:3.7.0'
   env:
     DRY_RUN: ${{ inputs.dry-run }}
     DEBUG_MODE: ${{ inputs.debug-mode }}


### PR DESCRIPTION
Auto-generated after release `v3.7.0` to keep `action.yml` in sync with the published container image. This PR is updated in place by the release pipeline; force-pushes will overwrite manual changes.