### PR TITLE
feat: add fallback-current-version input to emit last released version on no-release runs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -45,12 +45,21 @@ inputs:
     description: 'Create floating tags from major and minor versions after release.'
     required: false
     default: 'false'
+  fallback-current-version:
+    description:
+      'When no release is published, set release-version to the current (last released) version resolved from git tags
+      instead of leaving it empty. Defaults to false to preserve semantic-release''s native behavior (no version is
+      emitted when nothing is released).'
+    required: false
+    default: 'false'
 
 outputs:
   release-published:
     description: 'True if a new release is performed, false otherwise.'
   release-version:
-    description: 'New version or current version if not released, example: 1.2.3'
+    description:
+      'The published SemVer version (example: 1.2.3). Empty when no release is published, unless
+      fallback-current-version is enabled, in which case it is the current (last released) version.'
   release-major:
     description: 'New Major version of the semver, example: 1.'
   release-minor:
@@ -84,3 +93,4 @@ runs:
     - ${{ inputs.default-config }}
     - ${{ inputs.default-preset-info }}
     - ${{ inputs.floating-tags }}
+    - ${{ inputs.fallback-current-version }}

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -66,14 +66,15 @@ jobs:
 
 #### Action Variables
 
-| _Variable_              | _Default_ | _Details_                                                                                               |
-| ----------------------- | --------- | ------------------------------------------------------------------------------------------------------- |
-| **add-summary**         | `true`    | Add a GitHub Job Summary with release details                                                           |
-| **debug-mode**          | `false`   | To enable verbosity                                                                                     |
-| **dry-run**             | `false`   | Dry Run execution                                                                                       |
-| **default-config**      | `true`    | Force default config if not present                                                                     |
-| **default-preset-info** | `true`    | Inject opinionated `presetConfig`/`releaseRules` when a plugin uses `preset: "custom"`; see docs/FAQ.md |
-| **floating-tags**       | `false`   | Create floating tags from major and minor versions after release.                                       |
+| _Variable_                   | _Default_ | _Details_                                                                                                                    |
+| ---------------------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| **add-summary**              | `true`    | Add a GitHub Job Summary with release details                                                                                |
+| **debug-mode**               | `false`   | To enable verbosity                                                                                                          |
+| **dry-run**                  | `false`   | Dry Run execution                                                                                                            |
+| **default-config**           | `true`    | Force default config if not present                                                                                          |
+| **default-preset-info**      | `true`    | Inject opinionated `presetConfig`/`releaseRules` when a plugin uses `preset: "custom"`; see docs/FAQ.md                      |
+| **floating-tags**            | `false`   | Create floating tags from major and minor versions after release.                                                            |
+| **fallback-current-version** | `false`   | When no release is published, set `release-version` to the current (last released) version instead of empty. Off by default. |
 
 #### Environment Variables
 
@@ -87,17 +88,17 @@ By default semantic-release is only meant to perform releases, ignoring if furth
 (like using it in a maven project via `-Drevision=${release-version}`). But if you are in such scenarios you must update
 your release config file to force the system to publish the new versions.
 
-The Action will export multiple variables so they can be accessed within your workflows.L
+The Action will export multiple variables so they can be accessed within your workflows.
 
 ### Exported Variables
 
-| _Variable_            | _GitHub Action Output_ | _Example_                                  | _Details_                                           |
-| --------------------- | ---------------------- | ------------------------------------------ | --------------------------------------------------- |
-| **RELEASE_PUBLISHED** | **release-published**  | `true`                                     | True if a new release is published, false otherwise |
-| **RELEASE_VERSION**   | **release-version**    | `1.2.3`                                    | The new SemVer version of type X.Y.Z                |
-| **RELEASE_MAJOR**     | **release-major**      | `1`                                        | Major value of the new SemVer version               |
-| **RELEASE_MINOR**     | **release-minor**      | `2`                                        | Minor value of the new SemVer version               |
-| **RELEASE_PATCH**     | **release-patch**      | `3`                                        | Patch value of the new SemVer version               |
-| **RELEASE_TYPE**      | **release-type**       | `patch`                                    | Type of SemVer release: major, minor or patch       |
-| **RELEASE_GIT_HEAD**  | **release-git-head**   | `cddc1177c51b518b3263b1b4f2b50af77dcf8be9` | Commit ID of the release                            |
-| **RELEASE_GIT_TAG**   | **release-git-tag**    | `v1.2.3`                                   | Tag ID associated with the release                  |
+| _Variable_            | _GitHub Action Output_ | _Example_                                  | _Details_                                                                                      |
+| --------------------- | ---------------------- | ------------------------------------------ | ---------------------------------------------------------------------------------------------- |
+| **RELEASE_PUBLISHED** | **release-published**  | `true`                                     | True if a new release is published, false otherwise                                            |
+| **RELEASE_VERSION**   | **release-version**    | `1.2.3`                                    | New SemVer version (X.Y.Z); empty when no release unless `fallback-current-version` is enabled |
+| **RELEASE_MAJOR**     | **release-major**      | `1`                                        | Major value of the new SemVer version                                                          |
+| **RELEASE_MINOR**     | **release-minor**      | `2`                                        | Minor value of the new SemVer version                                                          |
+| **RELEASE_PATCH**     | **release-patch**      | `3`                                        | Patch value of the new SemVer version                                                          |
+| **RELEASE_TYPE**      | **release-type**       | `patch`                                    | Type of SemVer release: major, minor or patch                                                  |
+| **RELEASE_GIT_HEAD**  | **release-git-head**   | `cddc1177c51b518b3263b1b4f2b50af77dcf8be9` | Commit ID of the release                                                                       |
+| **RELEASE_GIT_TAG**   | **release-git-tag**    | `v1.2.3`                                   | Tag ID associated with the release                                                             |

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,8 @@
         "handlebars": "^4.7.8",
         "save-dev": "^0.0.1-security",
         "semantic-release": "^25.0.0",
-        "semantic-release-slack-bot": "^4.0.2"
+        "semantic-release-slack-bot": "^4.0.2",
+        "semver": "^7.8.5"
       },
       "devDependencies": {
         "@eslint/compat": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "handlebars": "^4.7.8",
     "save-dev": "^0.0.1-security",
     "semantic-release": "^25.0.0",
-    "semantic-release-slack-bot": "^4.0.2"
+    "semantic-release-slack-bot": "^4.0.2",
+    "semver": "^7.8.5"
   },
   "devDependencies": {
     "@eslint/compat": "2.1.0",

--- a/src/constants.js
+++ b/src/constants.js
@@ -10,6 +10,7 @@ const DRY_RUN = { name: 'dry-run', required: false, default: false }
 const DEBUG_MODE = { name: 'debug-mode', required: false, default: true }
 const CI = { name: 'ci', required: false, default: true }
 const FLOATING_TAGS = { name: 'floating-tags', required: false, default: false }
+const FALLBACK_CURRENT_VERSION = { name: 'fallback-current-version', required: false, default: false }
 const ADD_SUMMARY = { name: 'add-summary', required: false, default: true }
 const DEFAULT_CONFIG = { name: 'default-config', required: false, default: true }
 const DEFAULT_PRESET_INFO = { name: 'default-preset-info', required: false, default: true }
@@ -20,6 +21,7 @@ export const INPUTS = {
   DEBUG_MODE,
   CI,
   FLOATING_TAGS,
+  FALLBACK_CURRENT_VERSION,
   ADD_SUMMARY,
   DEFAULT_CONFIG,
   DEFAULT_PRESET_INFO,

--- a/src/get-last-release.js
+++ b/src/get-last-release.js
@@ -1,0 +1,82 @@
+import * as core from '@actions/core'
+import { execa } from 'execa'
+import semver from 'semver'
+
+// Captures a semantic version (with optional pre-release / build metadata) from a tag.
+const SEMVER = '(\\d+\\.\\d+\\.\\d+(?:[-+][0-9A-Za-z.-]+)*)'
+
+/**
+ * Builds a regex that extracts the version out of a git tag, honoring the same
+ * `tagFormat` semantic-release uses. When no format is configured, semantic-release
+ * defaults to `v${version}`, so we mirror that here.
+ *
+ * @param {string} tagFormat - The semantic-release tagFormat (may be empty).
+ * @returns {RegExp} A regex whose first capture group is the version.
+ */
+export const buildTagRegex = (tagFormat) => {
+  const format = tagFormat && tagFormat.length > 0 ? tagFormat : 'v${version}'
+  const [prefix, suffix = ''] = format.split('${version}')
+  const escape = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  return new RegExp(`^${escape(prefix)}${SEMVER}${escape(suffix)}$`)
+}
+
+/**
+ * Resolves the most recent released version from git tags. This is the equivalent
+ * of semantic-release's `lastRelease.version`, which it computes but does not
+ * expose when it publishes nothing (it returns `false`/`{ releases }` without
+ * `lastRelease`). This mirrors semantic-release's own `lib/get-last-release.js`
+ * for a stable branch: from the tags reachable from HEAD (semantic-release scopes
+ * to `git tag --merged <branch>`), keep valid, non-pre-release versions and take
+ * the highest by semver precedence (semver ordering, not git's `--sort=v:refname`,
+ * which ranks pre-releases above their stable counterpart).
+ *
+ * @param {string} tagFormat - The semantic-release tagFormat (may be empty).
+ * @param {Object} [options] - Execution options.
+ * @param {string} [options.cwd=process.cwd()] - The current working directory.
+ * @param {Object} [options.env=process.env] - The environment variables.
+ * @returns {Promise<string>} The current version, or '' when no release tag exists.
+ */
+export const getLastReleaseVersion = async (tagFormat, { cwd = process.cwd(), env = process.env } = {}) => {
+  const regex = buildTagRegex(tagFormat)
+  let output
+  try {
+    output = await execa('git', ['tag', '--merged', 'HEAD'], { cwd, env })
+  } catch (error) {
+    core.warning(`Unable to list git tags to resolve the current version: ${error?.message ?? error}`)
+    return ''
+  }
+  const versions = []
+  for (const tag of output.stdout.split('\n').map((line) => line.trim())) {
+    const match = regex.exec(tag)
+    // Skip pre-releases: like semantic-release, a stable branch's last release is
+    // the highest stable tag; a lone pre-release is not treated as a release.
+    if (match && semver.valid(match[1]) && !semver.prerelease(match[1])) {
+      versions.push(match[1])
+    }
+  }
+  return versions.length > 0 ? semver.rsort(versions)[0] : ''
+}
+
+/**
+ * Opt-in fallback (enabled via the `fallback-current-version` input): when
+ * semantic-release publishes nothing, populate RELEASE_VERSION with the current
+ * (last released) version so downstream consumers receive a valid tag instead of
+ * an empty value. Off by default to preserve semantic-release's native behavior.
+ *
+ * @param {string} tagFormat - The semantic-release tagFormat (may be empty).
+ * @param {Object} [options] - Execution options.
+ * @param {string} [options.cwd=process.cwd()] - The current working directory.
+ * @param {Object} [options.env=process.env] - The environment variables.
+ * @returns {Promise<string>} The exported version, or '' when none was found.
+ */
+export const exportCurrentVersion = async (tagFormat, { cwd = process.cwd(), env = process.env } = {}) => {
+  const version = await getLastReleaseVersion(tagFormat, { cwd, env })
+  if (!version) {
+    core.info('No previous release tag found; RELEASE_VERSION left unset.')
+    return ''
+  }
+  core.info(`No release published; setting RELEASE_VERSION to current version ${version}.`)
+  core.exportVariable('RELEASE_VERSION', version)
+  core.setOutput('release-version', version)
+  return version
+}

--- a/src/main.js
+++ b/src/main.js
@@ -5,7 +5,8 @@ import { runSemanticRelease } from './semantic-release.js'
 import { setSummary } from './set-summary.js'
 import { verifyRelease } from './verify-release.js'
 import { setFloatingTags } from './set-floating-tags.js'
-import { getBooleanInput, getInput } from './utils.js'
+import { exportCurrentVersion } from './get-last-release.js'
+import { getBooleanInput, getInput, isPullOrMergeRequest } from './utils.js'
 import { INPUTS } from './constants.js'
 
 /**
@@ -27,7 +28,16 @@ export async function run() {
     const options = await getOptions(config)
     const result = await runSemanticRelease(options, workDir)
     if (!result) {
-      core.info('No release is published, stopping here.')
+      // By default respect semantic-release: when nothing is released, emit no
+      // version. Opt in with `fallback-current-version` to set RELEASE_VERSION to
+      // the current (last released) version instead of leaving it empty. Skip on
+      // pull/merge requests, where the CI wrapper already sets a short SHA.
+      if (getBooleanInput(INPUTS.FALLBACK_CURRENT_VERSION) && !isPullOrMergeRequest()) {
+        core.info('No release is published; fallback-current-version enabled, resolving the last released version.')
+        await exportCurrentVersion(options.tagFormat, { cwd: workDir })
+      } else {
+        core.info('No release is published, stopping here.')
+      }
       return
     }
     const release = await verifyRelease(result)

--- a/src/utils.js
+++ b/src/utils.js
@@ -118,3 +118,17 @@ export const transformKey = (key) => {
 export const getEnvVar = (envVar, defaultValue) => {
   return process.env[envVar] || defaultValue
 }
+
+/**
+ * Determines whether the current run is a pull request (GitHub) or merge request
+ * (GitLab). In those contexts semantic-release publishes nothing and the CI
+ * wrapper supplies RELEASE_VERSION as a short SHA, so the "last released version"
+ * fallback must not run.
+ *
+ * @returns {boolean} `true` for pull/merge request runs, otherwise `false`.
+ */
+export const isPullOrMergeRequest = () => {
+  return (
+    getEnvVar('EVENT_NAME', '') === 'pull_request' || (isGitLabCi() && getEnvVar('CI_MERGE_REQUEST_IID', '') !== '')
+  )
+}

--- a/test/get-last-release.test.js
+++ b/test/get-last-release.test.js
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as core from '@actions/core'
+import { execa } from 'execa'
+import { buildTagRegex, exportCurrentVersion, getLastReleaseVersion } from '../src/get-last-release.js'
+
+vi.mock('@actions/core')
+vi.mock('execa')
+
+describe('buildTagRegex', () => {
+  it('defaults to the semantic-release "v${version}" format when none is given', () => {
+    const regex = buildTagRegex('')
+    expect(regex.exec('v1.2.3')?.[1]).toBe('1.2.3')
+    expect(regex.test('v1')).toBe(false)
+    expect(regex.test('v1.5')).toBe(false)
+  })
+
+  it('captures pre-release and build metadata', () => {
+    const regex = buildTagRegex('v${version}')
+    expect(regex.exec('v1.2.3-beta.1')?.[1]).toBe('1.2.3-beta.1')
+  })
+
+  it('honors a custom tag format', () => {
+    const regex = buildTagRegex('release-${version}')
+    expect(regex.exec('release-2.0.0')?.[1]).toBe('2.0.0')
+    expect(regex.test('v2.0.0')).toBe(false)
+  })
+})
+
+describe('getLastReleaseVersion', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns the highest semver tag, ignoring floating tags', async () => {
+    execa.mockResolvedValue({ stdout: 'v1.5.0\nv1.5\nv1\nv1.4.2' })
+    const version = await getLastReleaseVersion('', { cwd: '.', env: {} })
+    expect(version).toBe('1.5.0')
+    expect(execa).toHaveBeenCalledWith('git', ['tag', '--merged', 'HEAD'], { cwd: '.', env: {} })
+  })
+
+  it('picks the highest stable version and ignores pre-releases', async () => {
+    execa.mockResolvedValue({ stdout: 'v1.5.0-beta.1\nv1.5.0\nv1.4.2' })
+    expect(await getLastReleaseVersion('', { cwd: '.', env: {} })).toBe('1.5.0')
+  })
+
+  it('returns an empty string when only pre-release tags exist (matches semantic-release)', async () => {
+    execa.mockResolvedValue({ stdout: 'v1.5.0-beta.1\nv1.5.0-alpha.1' })
+    expect(await getLastReleaseVersion('', { cwd: '.', env: {} })).toBe('')
+  })
+
+  it('returns an empty string when there are no tags', async () => {
+    execa.mockResolvedValue({ stdout: '' })
+    expect(await getLastReleaseVersion('', { cwd: '.', env: {} })).toBe('')
+  })
+
+  it('warns and returns an empty string when git fails', async () => {
+    execa.mockRejectedValue(new Error('not a git repository'))
+    const version = await getLastReleaseVersion('', { cwd: '.', env: {} })
+    expect(version).toBe('')
+    expect(core.warning).toHaveBeenCalledWith(expect.stringMatching(/Unable to list git tags/))
+  })
+})
+
+describe('exportCurrentVersion', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('exports RELEASE_VERSION and the release-version output when a version is found', async () => {
+    execa.mockResolvedValue({ stdout: 'v1.5.0\nv1.4.2' })
+    const version = await exportCurrentVersion('', { cwd: '.', env: {} })
+    expect(version).toBe('1.5.0')
+    expect(core.exportVariable).toHaveBeenCalledWith('RELEASE_VERSION', '1.5.0')
+    expect(core.setOutput).toHaveBeenCalledWith('release-version', '1.5.0')
+  })
+
+  it('leaves RELEASE_VERSION unset when no release tag exists', async () => {
+    execa.mockResolvedValue({ stdout: '' })
+    const version = await exportCurrentVersion('', { cwd: '.', env: {} })
+    expect(version).toBe('')
+    expect(core.exportVariable).not.toHaveBeenCalled()
+    expect(core.setOutput).not.toHaveBeenCalled()
+    expect(core.info).toHaveBeenCalledWith(expect.stringMatching(/RELEASE_VERSION left unset/))
+  })
+})

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,5 +1,13 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { parseInput, cleanObject, getBooleanInput, getInput, isGitLabCi, transformKey } from '../src/utils.js'
+import {
+  parseInput,
+  cleanObject,
+  getBooleanInput,
+  getInput,
+  isGitLabCi,
+  isPullOrMergeRequest,
+  transformKey
+} from '../src/utils.js'
 import * as core from '@actions/core'
 import { INPUTS } from '../src/constants.js'
 
@@ -327,5 +335,37 @@ describe('isGitLabCi', () => {
     expect(result).toBe(false)
 
     process.env = originalProcessEnv // Restore process.env
+  })
+})
+
+describe('isPullOrMergeRequest', () => {
+  afterEach(() => {
+    delete process.env.EVENT_NAME
+    delete process.env.CI
+    delete process.env.GITLAB_CI
+    delete process.env.CI_MERGE_REQUEST_IID
+  })
+
+  it('returns true for a GitHub pull_request event', () => {
+    process.env.EVENT_NAME = 'pull_request'
+    expect(isPullOrMergeRequest()).toBe(true)
+  })
+
+  it('returns true for a GitLab merge request pipeline', () => {
+    process.env.CI = 'true'
+    process.env.GITLAB_CI = 'true'
+    process.env.CI_MERGE_REQUEST_IID = '42'
+    expect(isPullOrMergeRequest()).toBe(true)
+  })
+
+  it('returns false for a GitLab branch pipeline without a merge request', () => {
+    process.env.CI = 'true'
+    process.env.GITLAB_CI = 'true'
+    expect(isPullOrMergeRequest()).toBe(false)
+  })
+
+  it('returns false for a GitHub push event', () => {
+    process.env.EVENT_NAME = 'push'
+    expect(isPullOrMergeRequest()).toBe(false)
   })
 })


### PR DESCRIPTION
## Problem

When semantic-release publishes nothing (a non-releasing commit — `ci:`/`chore:`/`docs:` — lands on the default branch), the action returns early and leaves `RELEASE_VERSION` empty. Downstream consumers that use `RELEASE_VERSION` unguarded then fail (e.g. `oras pull repo/name:` → "no tag or digest specified").

This is expected semantic-release behavior — verified by running the tool directly (dry-run):

| Since last tag | Library return | CLI exit | `lastRelease` exposed? |
| --- | --- | --- | --- |
| `chore:` only | `false` | `0` | no |
| `feat:` | `{ lastRelease, commits, nextRelease, releases }` | `0` | yes |

semantic-release computes `lastRelease` internally (it even logs `Found git tag v1.0.0…`) but does not return it on the no-release path, and exposes no output mechanism natively. Surfacing the current version there is an open upstream feature request (semantic-release#3328). So the gap is in this action's contract, not in semantic-release.

## Change

Add an opt-in input **`fallback-current-version`** (default `false`):

- **Default (`false`)** — preserve semantic-release's native behavior: no version emitted when nothing is released.
- **`true`** — set `RELEASE_VERSION` / `release-version` to the current (last released) version, resolved from git tags, so consumers receive a valid tag instead of an empty value.
- Skipped on pull/merge requests, where the short SHA is already provided.

The resolver mirrors semantic-release's own `lib/get-last-release.js`: branch-reachable tags (`git tag --merged HEAD`) → valid semver → exclude pre-releases → highest by `semver.rcompare`. `semver` is promoted to a direct dependency (already transitive via semantic-release).

Also corrects the previously misleading `release-version` output description (it claimed "current version if not released", which the code did not deliver) and documents the new input.

## Testing

- 145 unit tests pass (new `test/get-last-release.test.js`, extended `test/utils.test.js`); eslint + prettier clean.
- End-to-end against throwaway git repos: stable beats pre-release and floating tags; a higher tag on an unmerged branch is correctly ignored; pre-release-only and no-tag repos resolve to empty; custom `tagFormat` honored.
